### PR TITLE
Phase 1: Dynamic channel config data model, NVS persistence, and TLV commands

### DIFF
--- a/ctl/src/handlers/net.rs
+++ b/ctl/src/handlers/net.rs
@@ -3,7 +3,7 @@
 use super::Core;
 use crate::{
     GetSetString, NetAction, NetLoopbackAction, PinAction, PinLevel, ResetAction,
-    WifiAction,
+    SetOnlyString, WifiAction,
 };
 use indicatif::{ProgressBar, ProgressStyle};
 use link::ctl::flash::StdDelay;
@@ -78,6 +78,11 @@ pub async fn handle_net(
             | NetAction::RelayUrl { .. }
             | NetAction::Loopback { .. }
             | NetAction::JitterStats { .. }
+            | NetAction::ConfigUrl { .. }
+            | NetAction::AccessToken { .. }
+            | NetAction::RefreshToken { .. }
+            | NetAction::Language { .. }
+            | NetAction::Channel { .. }
     );
 
     if needs_net_firmware {
@@ -407,5 +412,50 @@ pub async fn handle_net(
             println!("  state:     {}", stats.state);
             Ok(())
         }
+        NetAction::ConfigUrl { action } => match action {
+            SetOnlyString::Set { value } => {
+                core.set_config_url(&value).await?;
+                println!("Config URL set");
+                Ok(())
+            }
+        },
+        NetAction::AccessToken { action } => match action {
+            SetOnlyString::Set { value } => {
+                core.set_access_token(&value).await?;
+                println!("Access token set");
+                Ok(())
+            }
+        },
+        NetAction::RefreshToken { action } => match action {
+            SetOnlyString::Set { value } => {
+                core.set_refresh_token(&value).await?;
+                println!("Refresh token set");
+                Ok(())
+            }
+        },
+        NetAction::Language { action } => match action.unwrap_or_default() {
+            GetSetString::Get => {
+                let lang = core.get_language().await?;
+                println!("{}", lang);
+                Ok(())
+            }
+            GetSetString::Set { value } => {
+                core.set_language(&value).await?;
+                println!("Language set to {}", value);
+                Ok(())
+            }
+        },
+        NetAction::Channel { action } => match action.unwrap_or_default() {
+            GetSetString::Get => {
+                let (id, name) = core.get_channel().await?;
+                println!("{}\t{}", id, name);
+                Ok(())
+            }
+            GetSetString::Set { value } => {
+                core.set_channel(&value).await?;
+                println!("Channel set to {}", value);
+                Ok(())
+            }
+        },
     }
 }

--- a/ctl/src/main.rs
+++ b/ctl/src/main.rs
@@ -264,6 +264,14 @@ enum GetSetString {
     },
 }
 
+#[derive(Debug, Clone, Subcommand)]
+enum SetOnlyString {
+    /// Set a new value
+    Set {
+        value: String,
+    },
+}
+
 #[derive(Debug, Clone, Default, Subcommand)]
 enum LoopbackAction {
     /// Get the current loopback mode
@@ -352,6 +360,39 @@ enum NetAction {
     JitterStats {
         /// Channel ID (0=Ptt, 1=PttAi)
         channel_id: u8,
+    },
+
+    /// Set the config WebSocket URL
+    #[command(name = "config-url")]
+    ConfigUrl {
+        #[command(subcommand)]
+        action: SetOnlyString,
+    },
+
+    /// Set the OAuth access token
+    #[command(name = "access-token")]
+    AccessToken {
+        #[command(subcommand)]
+        action: SetOnlyString,
+    },
+
+    /// Set the OAuth refresh token
+    #[command(name = "refresh-token")]
+    RefreshToken {
+        #[command(subcommand)]
+        action: SetOnlyString,
+    },
+
+    /// Get or set the language
+    Language {
+        #[command(subcommand)]
+        action: Option<GetSetString>,
+    },
+
+    /// Get or set the active channel
+    Channel {
+        #[command(subcommand)]
+        action: Option<GetSetString>,
     },
 }
 

--- a/docs/tlv-protocol-spec.md
+++ b/docs/tlv-protocol-spec.md
@@ -1,7 +1,7 @@
 # Link TLV Protocol Specification
 
-**Version:** 1.2
-**Date:** 2026-02-11
+**Version:** 1.3
+**Date:** 2026-02-26
 
 ## 1. Overview
 
@@ -221,6 +221,13 @@ Messages from CTL to NET chip (tunneled through MGMT).
 | 0x47  | SetLoopback        | 1 byte (NetLoopbackMode) | Ack                          |
 | 0x48  | GetLoopback        | (empty)                  | Loopback                     |
 | 0x49  | GetJitterStats     | 1 byte (channel_id)      | JitterStats                  |
+| 0x4A  | SetConfigUrl       | UTF-8 URL string         | Ack                          |
+| 0x4B  | SetAccessToken     | UTF-8 token string       | Ack                          |
+| 0x4C  | SetRefreshToken    | UTF-8 token string       | Ack                          |
+| 0x4D  | GetLanguage        | (empty)                  | Language                     |
+| 0x4E  | SetLanguage        | UTF-8 language code      | Ack                          |
+| 0x4F  | GetChannel         | (empty)                  | ChannelInfo                  |
+| 0x50  | SetChannel         | UTF-8 display name       | Ack                          |
 
 ### 6.6 NetToCtl (0x5X)
 
@@ -236,6 +243,8 @@ Messages from NET chip to CTL (forwarded through MGMT via MgmtToCtl::FromNet).
 | 0x55  | Error         | UTF-8 error message                 | Error response              |
 | 0x56  | Loopback      | 1 byte (NetLoopbackMode)            | Response to GetLoopback     |
 | 0x57  | JitterStats   | postcard-serialized JitterStatsInfo | Response to GetJitterStats  |
+| 0x58  | Language      | UTF-8 language code                 | Response to GetLanguage     |
+| 0x59  | ChannelInfo   | UTF-8 JSON {"id":"...","display_name":"..."} | Response to GetChannel |
 
 ### 6.7 UiToNet (0x6X)
 

--- a/link/src/ctl/core.rs
+++ b/link/src/ctl/core.rs
@@ -1087,6 +1087,147 @@ impl<P: CtlPort> CtlCore<P> {
         Ok(stats)
     }
 
+    /// Set config WebSocket URL in NET chip storage.
+    pub async fn set_config_url(&mut self, url: &str) -> Result<(), CtlError> {
+        self.write_tlv_net(CtlToNet::SetConfigUrl, url.as_bytes())
+            .await?;
+        let tlv = self.read_tlv_net().await?;
+        if tlv.tlv_type == NetToCtl::Error {
+            let msg = core::str::from_utf8(&tlv.value).unwrap_or("<invalid utf8>");
+            return Err(CtlError::DeviceError(msg.into()));
+        }
+        if tlv.tlv_type != NetToCtl::Ack {
+            return Err(CtlError::UnexpectedResponse {
+                expected: "Ack",
+                actual: format!("{:?}", tlv.tlv_type),
+            });
+        }
+        Ok(())
+    }
+
+    /// Set OAuth access token in NET chip storage.
+    pub async fn set_access_token(&mut self, token: &str) -> Result<(), CtlError> {
+        self.write_tlv_net(CtlToNet::SetAccessToken, token.as_bytes())
+            .await?;
+        let tlv = self.read_tlv_net().await?;
+        if tlv.tlv_type == NetToCtl::Error {
+            let msg = core::str::from_utf8(&tlv.value).unwrap_or("<invalid utf8>");
+            return Err(CtlError::DeviceError(msg.into()));
+        }
+        if tlv.tlv_type != NetToCtl::Ack {
+            return Err(CtlError::UnexpectedResponse {
+                expected: "Ack",
+                actual: format!("{:?}", tlv.tlv_type),
+            });
+        }
+        Ok(())
+    }
+
+    /// Set OAuth refresh token in NET chip storage.
+    pub async fn set_refresh_token(&mut self, token: &str) -> Result<(), CtlError> {
+        self.write_tlv_net(CtlToNet::SetRefreshToken, token.as_bytes())
+            .await?;
+        let tlv = self.read_tlv_net().await?;
+        if tlv.tlv_type == NetToCtl::Error {
+            let msg = core::str::from_utf8(&tlv.value).unwrap_or("<invalid utf8>");
+            return Err(CtlError::DeviceError(msg.into()));
+        }
+        if tlv.tlv_type != NetToCtl::Ack {
+            return Err(CtlError::UnexpectedResponse {
+                expected: "Ack",
+                actual: format!("{:?}", tlv.tlv_type),
+            });
+        }
+        Ok(())
+    }
+
+    /// Get current language from NET chip.
+    pub async fn get_language(&mut self) -> Result<String, CtlError> {
+        self.write_tlv_net(CtlToNet::GetLanguage, &[]).await?;
+        let tlv = self.read_tlv_net().await?;
+        if tlv.tlv_type == NetToCtl::Error {
+            let msg = core::str::from_utf8(&tlv.value).unwrap_or("<invalid utf8>");
+            return Err(CtlError::DeviceError(msg.into()));
+        }
+        if tlv.tlv_type != NetToCtl::Language {
+            return Err(CtlError::UnexpectedResponse {
+                expected: "Language",
+                actual: format!("{:?}", tlv.tlv_type),
+            });
+        }
+        let lang = core::str::from_utf8(&tlv.value).map_err(|_| CtlError::InvalidUtf8)?;
+        Ok(lang.into())
+    }
+
+    /// Set language on NET chip.
+    pub async fn set_language(&mut self, lang: &str) -> Result<(), CtlError> {
+        self.write_tlv_net(CtlToNet::SetLanguage, lang.as_bytes())
+            .await?;
+        let tlv = self.read_tlv_net().await?;
+        if tlv.tlv_type == NetToCtl::Error {
+            let msg = core::str::from_utf8(&tlv.value).unwrap_or("<invalid utf8>");
+            return Err(CtlError::DeviceError(msg.into()));
+        }
+        if tlv.tlv_type != NetToCtl::Ack {
+            return Err(CtlError::UnexpectedResponse {
+                expected: "Ack",
+                actual: format!("{:?}", tlv.tlv_type),
+            });
+        }
+        Ok(())
+    }
+
+    /// Get current channel from NET chip. Returns (id, display_name).
+    pub async fn get_channel(&mut self) -> Result<(String, String), CtlError> {
+        self.write_tlv_net(CtlToNet::GetChannel, &[]).await?;
+        let tlv = self.read_tlv_net().await?;
+        if tlv.tlv_type == NetToCtl::Error {
+            let msg = core::str::from_utf8(&tlv.value).unwrap_or("<invalid utf8>");
+            return Err(CtlError::DeviceError(msg.into()));
+        }
+        if tlv.tlv_type != NetToCtl::ChannelInfo {
+            return Err(CtlError::UnexpectedResponse {
+                expected: "ChannelInfo",
+                actual: format!("{:?}", tlv.tlv_type),
+            });
+        }
+        // Parse JSON: {"id":"...","display_name":"..."}
+        let json_str = core::str::from_utf8(&tlv.value).map_err(|_| CtlError::InvalidUtf8)?;
+        // Simple manual parse to avoid adding serde_json dependency to link crate
+        let id = Self::extract_json_string(json_str, "id")
+            .ok_or(CtlError::InvalidData)?;
+        let display_name = Self::extract_json_string(json_str, "display_name")
+            .ok_or(CtlError::InvalidData)?;
+        Ok((id, display_name))
+    }
+
+    /// Set channel by display name on NET chip.
+    pub async fn set_channel(&mut self, display_name: &str) -> Result<(), CtlError> {
+        self.write_tlv_net(CtlToNet::SetChannel, display_name.as_bytes())
+            .await?;
+        let tlv = self.read_tlv_net().await?;
+        if tlv.tlv_type == NetToCtl::Error {
+            let msg = core::str::from_utf8(&tlv.value).unwrap_or("<invalid utf8>");
+            return Err(CtlError::DeviceError(msg.into()));
+        }
+        if tlv.tlv_type != NetToCtl::Ack {
+            return Err(CtlError::UnexpectedResponse {
+                expected: "Ack",
+                actual: format!("{:?}", tlv.tlv_type),
+            });
+        }
+        Ok(())
+    }
+
+    /// Extract a string value from simple JSON like {"key":"value",...}.
+    fn extract_json_string(json: &str, key: &str) -> Option<String> {
+        let pattern = format!("\"{}\":\"", key);
+        let start = json.find(&pattern)? + pattern.len();
+        let rest = &json[start..];
+        let end = rest.find('"')?;
+        Some(rest[..end].into())
+    }
+
     /// Set NET chip BOOT pin directly.
     pub async fn set_net_boot(&mut self, value: crate::shared::PinValue) -> Result<(), CtlError> {
         use crate::shared::Pin;

--- a/link/src/lib.rs
+++ b/link/src/lib.rs
@@ -50,6 +50,10 @@ pub use shared::tlv::Tlv;
 #[cfg(feature = "ctl")]
 pub use shared::wifi::WifiSsid;
 
+// Re-export config types for net and ctl
+#[cfg(any(feature = "net", feature = "ctl"))]
+pub use shared::config;
+
 // Re-export protocol types
 pub use shared::protocol::{
     ChannelId, CtlToMgmt, CtlToNet, CtlToUi, JitterStatsInfo, MgmtToCtl, NetLoopbackMode,

--- a/link/src/net/mod.rs
+++ b/link/src/net/mod.rs
@@ -436,6 +436,19 @@ async fn handle_mgmt<'a, M, U, F, RM: RawMutex, const N: usize>(
                 .must_write_tlv(NetToCtl::Error, b"no jitter buffer")
                 .await;
         }
+        CtlToNet::SetConfigUrl
+        | CtlToNet::SetAccessToken
+        | CtlToNet::SetRefreshToken
+        | CtlToNet::GetLanguage
+        | CtlToNet::SetLanguage
+        | CtlToNet::GetChannel
+        | CtlToNet::SetChannel => {
+            // Config commands handled by ESP-IDF firmware (net/src/main.rs), not embassy
+            info!("net: config command not supported in embassy mode");
+            to_mgmt
+                .must_write_tlv(NetToCtl::Error, b"not supported")
+                .await;
+        }
     }
 }
 

--- a/link/src/shared/config.rs
+++ b/link/src/shared/config.rs
@@ -1,0 +1,126 @@
+//! Configuration data types for dynamic channel configuration.
+//!
+//! These types match the JSON schema sent by the config WebSocket feed.
+
+extern crate alloc;
+
+use alloc::string::String;
+use alloc::vec::Vec;
+use serde::{Deserialize, Serialize};
+
+/// A PTT/chat track identified by namespace segments and track name.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct TrackRef {
+    pub namespace: Vec<String>,
+    pub name: String,
+}
+
+/// Language-specific tracks for a channel.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ChannelLanguageTracks {
+    pub ptt: TrackRef,
+    pub chat: TrackRef,
+}
+
+/// A channel configuration.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ChannelConfig {
+    pub id: String,
+    pub display_name: String,
+    pub users: Vec<String>,
+    pub languages: alloc::collections::BTreeMap<String, ChannelLanguageTracks>,
+}
+
+/// Language-specific tracks for the AI service.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AiLanguageTracks {
+    pub namespace: Vec<String>,
+    pub name: String,
+}
+
+/// AI service configuration.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AiConfig {
+    pub name: String,
+    pub languages: alloc::collections::BTreeMap<String, AiLanguageTracks>,
+    pub response_ns: Vec<String>,
+}
+
+/// A WiFi network in the config feed.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ConfigWifiNetwork {
+    pub ssid: String,
+    #[serde(default)]
+    pub password: Option<String>,
+}
+
+/// Top-level device configuration from the config feed.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct DeviceConfig {
+    pub relay_url: String,
+    pub trial_name: String,
+    pub trial_id: String,
+    pub user_id: String,
+    pub user_directory: String,
+    pub ai: AiConfig,
+    pub channels: Vec<ChannelConfig>,
+    pub wifi_networks: Vec<ConfigWifiNetwork>,
+}
+
+/// Supported languages.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Language {
+    En,
+    De,
+    Es,
+    Hi,
+    No,
+}
+
+impl Language {
+    /// Parse from a language code string.
+    pub fn from_str_code(s: &str) -> Option<Self> {
+        match s {
+            "en" => Some(Language::En),
+            "de" => Some(Language::De),
+            "es" => Some(Language::Es),
+            "hi" => Some(Language::Hi),
+            "no" => Some(Language::No),
+            _ => None,
+        }
+    }
+
+    /// Return the language code string.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Language::En => "en",
+            Language::De => "de",
+            Language::Es => "es",
+            Language::Hi => "hi",
+            Language::No => "no",
+        }
+    }
+
+    /// All valid language code strings.
+    pub const VALID_CODES: &[&str] = &["en", "de", "es", "hi", "no"];
+}
+
+impl Default for Language {
+    fn default() -> Self {
+        Language::En
+    }
+}
+
+impl core::fmt::Display for Language {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Credentials for connecting to the config WebSocket feed.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ConfigCredentials {
+    pub config_url: String,
+    pub access_token: String,
+    pub refresh_token: String,
+}

--- a/link/src/shared/mod.rs
+++ b/link/src/shared/mod.rs
@@ -3,6 +3,9 @@
 #[cfg(feature = "ctl")]
 pub mod chip_config;
 pub mod chunk;
+// Config types - used by net and ctl (requires alloc)
+#[cfg(any(feature = "net", feature = "ctl"))]
+pub mod config;
 #[cfg(feature = "ctl")]
 pub mod protocol_config;
 #[cfg(any(feature = "mgmt", feature = "ui"))]

--- a/link/src/shared/protocol.rs
+++ b/link/src/shared/protocol.rs
@@ -208,6 +208,20 @@ pub enum CtlToNet {
     GetLoopback,
     /// Get jitter buffer stats for a channel (value: channel_id u8)
     GetJitterStats,
+    /// Set config WebSocket URL (UTF-8 string)
+    SetConfigUrl,
+    /// Set OAuth access token (UTF-8 string)
+    SetAccessToken,
+    /// Set OAuth refresh token (UTF-8 string)
+    SetRefreshToken,
+    /// Get current language
+    GetLanguage,
+    /// Set language (UTF-8: "en"|"de"|"es"|"hi"|"no")
+    SetLanguage,
+    /// Get current channel
+    GetChannel,
+    /// Set channel by display name (UTF-8 string)
+    SetChannel,
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, IntoPrimitive, TryFromPrimitive)]
@@ -223,6 +237,10 @@ pub enum NetToCtl {
     Loopback,
     /// Jitter buffer statistics (postcard-serialized JitterStatsInfo)
     JitterStats,
+    /// Current language (UTF-8 string)
+    Language,
+    /// Channel info (UTF-8 JSON: {"id":"...","display_name":"..."})
+    ChannelInfo,
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, IntoPrimitive, TryFromPrimitive)]

--- a/net/Cargo.toml
+++ b/net/Cargo.toml
@@ -32,6 +32,8 @@ heapless = { version = "0.9", features = ["serde"] }
 postcard = { version = "1", features = ["alloc"] }
 embedded-io = "0.7"
 embedded-svc = { version = "0.28.1", default-features = false }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 
 [build-dependencies]
 embuild = "0.33"

--- a/net/partitions.csv
+++ b/net/partitions.csv
@@ -1,5 +1,5 @@
 # ESP32-S3 Partition Table - 8MB Flash
 # Name,   Type, SubType, Offset,   Size
-nvs,      data, nvs,     0x9000,   0x6000
-phy_init, data, phy,     0xf000,   0x1000
-factory,  app,  factory, 0x10000,  0x400000
+nvs,      data, nvs,     0x9000,   0x10000
+phy_init, data, phy,     0x19000,  0x1000
+factory,  app,  factory, 0x20000,  0x3E0000

--- a/net/src/main.rs
+++ b/net/src/main.rs
@@ -19,6 +19,7 @@ use esp_idf_svc::{
     nvs::{EspDefaultNvsPartition, EspNvs, NvsDefault},
 };
 use link::{
+    config::{DeviceConfig, Language},
     net::{
         JitterBuffer, JitterState, WifiSsid, MAX_RELAY_URL_LEN,
         MAX_WIFI_SSIDS,
@@ -61,6 +62,15 @@ enum MoqCommand {
     SetPttChannel(PttChannel),
     /// Set loopback mode.
     SetLoopback(NetLoopbackMode),
+    /// Reconfigure MoQ tracks (channel/language change).
+    Reconfigure {
+        ptt_namespace: Vec<String>,
+        ptt_track_name: String,
+        ai_pub_namespace: Vec<String>,
+        ai_pub_track_name: String,
+        ai_sub_namespace: Vec<String>,
+        ai_sub_track_name: String,
+    },
 }
 
 /// Events sent from the MoQ task back to the main loop.
@@ -107,10 +117,89 @@ fn get_device_id_from_mac() -> u64 {
     (device_id << 2) >> 2
 }
 
+/// Track parameters for MoQ setup (derived from config + language + channel).
+#[derive(Clone)]
+struct TrackParams {
+    ptt_namespace: Vec<String>,
+    ptt_track_name: String,
+    ai_pub_namespace: Vec<String>,
+    ai_pub_track_name: String,
+    ai_sub_namespace: Vec<String>,
+    ai_sub_track_name: String,
+}
+
+/// Build default (hardcoded) track parameters as fallback when no config exists.
+fn default_track_params() -> TrackParams {
+    let ns_prefix = vec![
+        "moq://moq.ptt.arpa/v1".to_string(),
+        "org/acme".to_string(),
+        "store/1234".to_string(),
+    ];
+    let channel_name = "gardening";
+    let track_name = "pcm_en_8khz_mono_i16";
+
+    let mut ptt_ns = ns_prefix.clone();
+    ptt_ns.push(format!("channel/{}", channel_name));
+    ptt_ns.push("ptt".to_string());
+
+    let mut ai_ns = ns_prefix;
+    ai_ns.push("ai/audio".to_string());
+
+    let device_id_str = format!("{}", get_device_id_from_mac());
+
+    TrackParams {
+        ptt_namespace: ptt_ns,
+        ptt_track_name: track_name.to_string(),
+        ai_pub_namespace: ai_ns.clone(),
+        ai_pub_track_name: track_name.to_string(),
+        ai_sub_namespace: ai_ns,
+        ai_sub_track_name: device_id_str,
+    }
+}
+
+/// Derive track parameters from a DeviceConfig, language, and selected channel.
+fn track_params_from_config(
+    config: &DeviceConfig,
+    language: &str,
+    selected_channel: &str,
+) -> Option<TrackParams> {
+    // Find the selected channel
+    let channel = config
+        .channels
+        .iter()
+        .find(|c| c.display_name == selected_channel)
+        .or_else(|| config.channels.first())?;
+
+    // Get language-specific tracks (fall back to "en")
+    let lang_tracks = channel
+        .languages
+        .get(language)
+        .or_else(|| channel.languages.get("en"))?;
+
+    let device_id_str = format!("{}", get_device_id_from_mac());
+
+    // Get AI tracks for this language
+    let ai_lang = config
+        .ai
+        .languages
+        .get(language)
+        .or_else(|| config.ai.languages.get("en"))?;
+
+    Some(TrackParams {
+        ptt_namespace: lang_tracks.ptt.namespace.clone(),
+        ptt_track_name: lang_tracks.ptt.name.clone(),
+        ai_pub_namespace: ai_lang.namespace.clone(),
+        ai_pub_track_name: ai_lang.name.clone(),
+        ai_sub_namespace: config.ai.response_ns.clone(),
+        ai_sub_track_name: device_id_str,
+    })
+}
+
 /// Helper function to set up PTT tracks after connection.
 /// Returns true if setup was successful.
-fn setup_ptt_tracks(
+fn setup_tracks_from_params(
     client: &quicr::Client,
+    params: &TrackParams,
     ptt_pub_track: &mut Option<std::sync::Arc<quicr::PublishTrack>>,
     ai_pub_track: &mut Option<std::sync::Arc<quicr::PublishTrack>>,
     ptt_subscription: &mut Option<Subscription>,
@@ -120,40 +209,23 @@ fn setup_ptt_tracks(
     ai_group_id: &mut u64,
     ai_object_id: &mut u64,
 ) -> bool {
-    // Hactar track naming:
-    // Namespace prefix: moq://moq.ptt.arpa/v1/org/acme/store/1234
-    // PTT channel: .../channel/<name>/ptt + track pcm_en_8khz_mono_i16
-    // AI audio pub: .../ai/audio + track pcm_en_8khz_mono_i16
-    // AI audio sub: .../ai/audio + track <device_id>
-
-    let ns_prefix = &["moq://moq.ptt.arpa/v1", "org/acme", "store/1234"];
-    let channel_name = "gardening"; // TODO: make configurable
-    let track_name = "pcm_en_8khz_mono_i16";
-
-    // Register PTT namespace for publishing
-    let ptt_ns = TrackNamespace::from_strings(&[
-        ns_prefix[0],
-        ns_prefix[1],
-        ns_prefix[2],
-        &format!("channel/{}", channel_name),
-        "ptt",
-    ]);
+    let ptt_ns_strs: Vec<&str> = params.ptt_namespace.iter().map(|s| s.as_str()).collect();
+    let ptt_ns = TrackNamespace::from_strings(&ptt_ns_strs);
     client.publish_namespace(&ptt_ns);
 
-    // Register AI audio namespace for publishing
-    let ai_ns =
-        TrackNamespace::from_strings(&[ns_prefix[0], ns_prefix[1], ns_prefix[2], "ai/audio"]);
-    client.publish_namespace(&ai_ns);
+    let ai_pub_ns_strs: Vec<&str> = params.ai_pub_namespace.iter().map(|s| s.as_str()).collect();
+    let ai_pub_ns = TrackNamespace::from_strings(&ai_pub_ns_strs);
+    client.publish_namespace(&ai_pub_ns);
 
-    // Get device ID from MAC for group_id (janet uses this to route AI responses)
     let device_id = get_device_id_from_mac();
     info!("device id: {}", device_id);
 
     // Create PTT publish track
-    let ptt_track_name_full = FullTrackName::new(ptt_ns.clone(), track_name.as_bytes());
+    let ptt_track_name_full =
+        FullTrackName::new(ptt_ns.clone(), params.ptt_track_name.clone().into_bytes());
     info!(
         "MoQ PTT: publish namespace={}, track={} (device_id={})",
-        ptt_ns, track_name, device_id
+        ptt_ns, params.ptt_track_name, device_id
     );
     match block_on(client.publish(ptt_track_name_full)) {
         Ok(track) => {
@@ -172,8 +244,8 @@ fn setup_ptt_tracks(
     }
 
     // Create AI audio publish track
-    let ai_pub_track_name = FullTrackName::new(ai_ns.clone(), track_name.as_bytes());
-
+    let ai_pub_track_name =
+        FullTrackName::new(ai_pub_ns.clone(), params.ai_pub_track_name.clone().into_bytes());
     match block_on(client.publish(ai_pub_track_name)) {
         Ok(track) => {
             *ai_pub_track = Some(track);
@@ -190,10 +262,11 @@ fn setup_ptt_tracks(
     }
 
     // Subscribe to PTT channel (receive from others)
-    let ptt_sub_track_name = FullTrackName::new(ptt_ns.clone(), track_name.as_bytes());
+    let ptt_sub_track_name =
+        FullTrackName::new(ptt_ns.clone(), params.ptt_track_name.clone().into_bytes());
     info!(
         "MoQ PTT: subscribe namespace={}, track={}",
-        ptt_ns, track_name
+        ptt_ns, params.ptt_track_name
     );
     match block_on(client.subscribe(ptt_sub_track_name)) {
         Ok(sub) => {
@@ -205,16 +278,18 @@ fn setup_ptt_tracks(
         }
     }
 
-    // Subscribe to AI audio namespace first (to receive announcements for dynamic tracks)
-    client.subscribe_namespace(&ai_ns);
+    // Subscribe to AI audio namespace
+    let ai_sub_ns_strs: Vec<&str> = params.ai_sub_namespace.iter().map(|s| s.as_str()).collect();
+    let ai_sub_ns = TrackNamespace::from_strings(&ai_sub_ns_strs);
+    client.subscribe_namespace(&ai_sub_ns);
 
-    // Subscribe to AI audio responses (using device ID as track name)
-    let device_id_str = format!("{}", device_id);
+    // Subscribe to AI audio responses
     info!(
-        "MoQ PTT: subscribing to AI responses on ns={} track=\"{}\" track_bytes={:?} (device_id=0x{:012x})",
-        ai_ns, device_id_str, device_id_str.as_bytes(), device_id
+        "MoQ PTT: subscribing to AI responses on ns={} track=\"{}\" (device_id=0x{:012x})",
+        ai_sub_ns, params.ai_sub_track_name, device_id
     );
-    let ai_sub_track_name = FullTrackName::new(ai_ns, device_id_str.into_bytes());
+    let ai_sub_track_name =
+        FullTrackName::new(ai_sub_ns, params.ai_sub_track_name.clone().into_bytes());
     match block_on(client.subscribe(ai_sub_track_name)) {
         Ok(sub) => {
             *ai_subscription = Some(sub);
@@ -237,6 +312,7 @@ fn spawn_moq_task(
         String,
     )>,
     initial_relay_url: Option<String>,
+    initial_track_params: TrackParams,
     cmd_rx: Receiver<MoqCommand>,
     event_tx: Sender<MoqEvent>,
 ) {
@@ -283,6 +359,7 @@ fn spawn_moq_task(
             let mut ptt_recv_count: u64 = 0;
             let mut ai_recv_count: u64 = 0;
             let mut last_stats = Instant::now();
+            let mut track_params = initial_track_params;
 
             loop {
                 // Check for commands (non-blocking)
@@ -318,8 +395,9 @@ fn spawn_moq_task(
                                         let _ = event_tx.send(MoqEvent::Connected);
 
                                         // Auto-start PTT mode on connect
-                                        ptt_ready = setup_ptt_tracks(
+                                        ptt_ready = setup_tracks_from_params(
                                             &c,
+                                            &track_params,
                                             &mut ptt_pub_track,
                                             &mut ai_pub_track,
                                             &mut ptt_subscription,
@@ -344,6 +422,45 @@ fn spawn_moq_task(
                                 warn!("MoQ: failed to create client: {:?}", e);
                                 last_reconnect_attempt = Some(Instant::now());
                             }
+                        }
+                    }
+                    Ok(MoqCommand::Reconfigure {
+                        ptt_namespace,
+                        ptt_track_name,
+                        ai_pub_namespace,
+                        ai_pub_track_name,
+                        ai_sub_namespace,
+                        ai_sub_track_name,
+                    }) => {
+                        info!("MoQ: reconfiguring tracks");
+                        track_params = TrackParams {
+                            ptt_namespace,
+                            ptt_track_name,
+                            ai_pub_namespace,
+                            ai_pub_track_name,
+                            ai_sub_namespace,
+                            ai_sub_track_name,
+                        };
+                        // Tear down existing tracks
+                        ptt_pub_track = None;
+                        ai_pub_track = None;
+                        ptt_subscription = None;
+                        ai_subscription = None;
+                        ptt_ready = false;
+                        // Re-setup if connected
+                        if let Some(ref c) = client {
+                            ptt_ready = setup_tracks_from_params(
+                                c,
+                                &track_params,
+                                &mut ptt_pub_track,
+                                &mut ai_pub_track,
+                                &mut ptt_subscription,
+                                &mut ai_subscription,
+                                &mut ptt_group_id,
+                                &mut ptt_object_id,
+                                &mut ai_group_id,
+                                &mut ai_object_id,
+                            );
                         }
                     }
                     Ok(MoqCommand::SetPttChannel(channel)) => {
@@ -532,8 +649,9 @@ fn spawn_moq_task(
                                         let _ = event_tx.send(MoqEvent::Connected);
 
                                         // Auto-start PTT mode on reconnect
-                                        ptt_ready = setup_ptt_tracks(
+                                        ptt_ready = setup_tracks_from_params(
                                             &c,
+                                            &track_params,
                                             &mut ptt_pub_track,
                                             &mut ai_pub_track,
                                             &mut ptt_subscription,
@@ -575,23 +693,76 @@ struct NvsStorage {
     nvs: Option<EspNvs<NvsDefault>>,
     wifi_ssids: heapless::Vec<WifiSsid, MAX_WIFI_SSIDS>,
     relay_url: String,
+    config_url: String,
+    access_token: String,
+    refresh_token: String,
+    language: String,
+    selected_channel: String,
+    config_json: String,
 }
 
 // NVS key names (max 15 chars)
 const NVS_KEY_WIFI_SSIDS: &str = "wifi_ssids";
 const NVS_KEY_RELAY_URL: &str = "relay_url";
+const NVS_KEY_CONFIG_URL: &str = "config_url";
+const NVS_KEY_ACCESS_TOKEN: &str = "access_token";
+const NVS_KEY_REFRESH_TOKEN: &str = "refresh_token";
+const NVS_KEY_LANGUAGE: &str = "language";
+const NVS_KEY_SEL_CHANNEL: &str = "sel_channel";
+const NVS_KEY_CONFIG_JSON: &str = "config_json";
+
+/// Max size for config JSON blob in NVS
+const MAX_CONFIG_JSON_LEN: usize = 20480;
 
 impl NvsStorage {
+    /// Load a UTF-8 string from NVS blob.
+    fn load_string(nvs: &EspNvs<NvsDefault>, key: &str, max_len: usize) -> String {
+        let mut buf = vec![0u8; max_len];
+        match nvs.get_blob(key, &mut buf) {
+            Ok(Some(data)) => {
+                if let Ok(s) = core::str::from_utf8(data) {
+                    info!("net: loaded {} from NVS ({}B)", key, s.len());
+                    return s.to_string();
+                }
+            }
+            Ok(None) => {}
+            Err(e) => {
+                warn!("net: failed to read {} from NVS: {:?}", key, e);
+            }
+        }
+        String::new()
+    }
+
+    /// Save a UTF-8 string to NVS blob, or remove key if empty.
+    fn save_string(
+        nvs: &mut EspNvs<NvsDefault>,
+        key: &str,
+        value: &str,
+    ) -> Result<(), esp_idf_svc::sys::EspError> {
+        if !value.is_empty() {
+            nvs.set_blob(key, value.as_bytes())?;
+        } else {
+            let _ = nvs.remove(key);
+        }
+        Ok(())
+    }
+
     /// Load storage from NVS
     fn load(nvs: Option<EspNvs<NvsDefault>>) -> Self {
         let mut storage = Self {
             nvs,
             wifi_ssids: heapless::Vec::new(),
             relay_url: String::new(),
+            config_url: String::new(),
+            access_token: String::new(),
+            refresh_token: String::new(),
+            language: "en".to_string(),
+            selected_channel: String::new(),
+            config_json: String::new(),
         };
 
-        // Load WiFi SSIDs
         if let Some(ref nvs) = storage.nvs {
+            // Load WiFi SSIDs
             let mut buf = [0u8; 512];
             match nvs.get_blob(NVS_KEY_WIFI_SSIDS, &mut buf) {
                 Ok(Some(data)) => {
@@ -611,27 +782,22 @@ impl NvsStorage {
                 }
             }
 
-            // Load relay URL
-            let mut url_buf = [0u8; MAX_RELAY_URL_LEN];
-            match nvs.get_blob(NVS_KEY_RELAY_URL, &mut url_buf) {
-                Ok(Some(data)) => {
-                    if let Ok(url) = core::str::from_utf8(data) {
-                        storage.relay_url = url.to_string();
-                        info!("net: loaded relay URL from NVS: {}", storage.relay_url);
-                    }
-                }
-                Ok(None) => {}
-                Err(e) => {
-                    warn!("net: failed to read relay URL from NVS: {:?}", e);
-                }
+            storage.relay_url = Self::load_string(nvs, NVS_KEY_RELAY_URL, MAX_RELAY_URL_LEN);
+            storage.config_url = Self::load_string(nvs, NVS_KEY_CONFIG_URL, MAX_RELAY_URL_LEN);
+            storage.access_token = Self::load_string(nvs, NVS_KEY_ACCESS_TOKEN, 2048);
+            storage.refresh_token = Self::load_string(nvs, NVS_KEY_REFRESH_TOKEN, 2048);
+            let lang = Self::load_string(nvs, NVS_KEY_LANGUAGE, 8);
+            if !lang.is_empty() {
+                storage.language = lang;
             }
-
+            storage.selected_channel = Self::load_string(nvs, NVS_KEY_SEL_CHANNEL, 128);
+            storage.config_json = Self::load_string(nvs, NVS_KEY_CONFIG_JSON, MAX_CONFIG_JSON_LEN);
         }
 
         storage
     }
 
-    /// Save storage to NVS
+    /// Save all storage to NVS.
     fn save(&mut self) -> Result<(), esp_idf_svc::sys::EspError> {
         let Some(ref mut nvs) = self.nvs else {
             warn!("net: NVS not available, cannot save");
@@ -644,16 +810,32 @@ impl NvsStorage {
             info!("net: saved {} WiFi SSIDs to NVS", self.wifi_ssids.len());
         }
 
-        // Save relay URL
-        if !self.relay_url.is_empty() {
-            nvs.set_blob(NVS_KEY_RELAY_URL, self.relay_url.as_bytes())?;
-            info!("net: saved relay URL to NVS");
-        } else {
-            // Remove the key if URL is empty
-            let _ = nvs.remove(NVS_KEY_RELAY_URL);
-        }
+        Self::save_string(nvs, NVS_KEY_RELAY_URL, &self.relay_url)?;
+        Self::save_string(nvs, NVS_KEY_CONFIG_URL, &self.config_url)?;
+        Self::save_string(nvs, NVS_KEY_ACCESS_TOKEN, &self.access_token)?;
+        Self::save_string(nvs, NVS_KEY_REFRESH_TOKEN, &self.refresh_token)?;
+        Self::save_string(nvs, NVS_KEY_LANGUAGE, &self.language)?;
+        Self::save_string(nvs, NVS_KEY_SEL_CHANNEL, &self.selected_channel)?;
+        Self::save_string(nvs, NVS_KEY_CONFIG_JSON, &self.config_json)?;
 
         Ok(())
+    }
+
+    /// Save a single field to NVS without rewriting everything.
+    fn save_field(&mut self, key: &str, value: &str) -> Result<(), esp_idf_svc::sys::EspError> {
+        let Some(ref mut nvs) = self.nvs else {
+            warn!("net: NVS not available, cannot save");
+            return Ok(());
+        };
+        Self::save_string(nvs, key, value)
+    }
+
+    /// Parse stored config_json into DeviceConfig.
+    fn parsed_config(&self) -> Option<DeviceConfig> {
+        if self.config_json.is_empty() {
+            return None;
+        }
+        serde_json::from_str(&self.config_json).ok()
     }
 
     fn add_wifi_ssid(&mut self, ssid: &str, password: &str) -> Result<(), ()> {
@@ -808,7 +990,14 @@ fn main() {
     } else {
         None
     };
-    spawn_moq_task(wifi_config, initial_relay_url, moq_cmd_rx, moq_event_tx);
+
+    // Derive initial track params from stored config (or use defaults)
+    let initial_track_params = storage
+        .parsed_config()
+        .and_then(|cfg| track_params_from_config(&cfg, &storage.language, &storage.selected_channel))
+        .unwrap_or_else(default_track_params);
+
+    spawn_moq_task(wifi_config, initial_relay_url, initial_track_params, moq_cmd_rx, moq_event_tx);
 
     // Loopback mode state
     let mut loopback = NetLoopbackMode::Off;
@@ -1198,6 +1387,134 @@ fn handle_mgmt_message(
                 }
             } else {
                 write_tlv(mgmt_uart, NetToCtl::Error, b"invalid channel");
+            }
+        }
+        CtlToNet::SetConfigUrl => {
+            if let Ok(url) = core::str::from_utf8(value) {
+                storage.config_url = url.to_string();
+                if storage.save_field(NVS_KEY_CONFIG_URL, url).is_ok() {
+                    write_tlv(mgmt_uart, NetToCtl::Ack, &[]);
+                } else {
+                    write_tlv(mgmt_uart, NetToCtl::Error, b"save");
+                }
+            } else {
+                write_tlv(mgmt_uart, NetToCtl::Error, b"utf8");
+            }
+        }
+        CtlToNet::SetAccessToken => {
+            if let Ok(token) = core::str::from_utf8(value) {
+                storage.access_token = token.to_string();
+                if storage.save_field(NVS_KEY_ACCESS_TOKEN, token).is_ok() {
+                    write_tlv(mgmt_uart, NetToCtl::Ack, &[]);
+                } else {
+                    write_tlv(mgmt_uart, NetToCtl::Error, b"save");
+                }
+            } else {
+                write_tlv(mgmt_uart, NetToCtl::Error, b"utf8");
+            }
+        }
+        CtlToNet::SetRefreshToken => {
+            if let Ok(token) = core::str::from_utf8(value) {
+                storage.refresh_token = token.to_string();
+                if storage.save_field(NVS_KEY_REFRESH_TOKEN, token).is_ok() {
+                    write_tlv(mgmt_uart, NetToCtl::Ack, &[]);
+                } else {
+                    write_tlv(mgmt_uart, NetToCtl::Error, b"save");
+                }
+            } else {
+                write_tlv(mgmt_uart, NetToCtl::Error, b"utf8");
+            }
+        }
+        CtlToNet::GetLanguage => {
+            write_tlv(mgmt_uart, NetToCtl::Language, storage.language.as_bytes());
+        }
+        CtlToNet::SetLanguage => {
+            if let Ok(lang) = core::str::from_utf8(value) {
+                if Language::from_str_code(lang).is_some() {
+                    storage.language = lang.to_string();
+                    if storage.save_field(NVS_KEY_LANGUAGE, lang).is_ok() {
+                        // Trigger reconfiguration if we have a config
+                        if let Some(cfg) = storage.parsed_config() {
+                            if let Some(params) = track_params_from_config(
+                                &cfg,
+                                &storage.language,
+                                &storage.selected_channel,
+                            ) {
+                                let _ = moq_cmd_tx.send(MoqCommand::Reconfigure {
+                                    ptt_namespace: params.ptt_namespace,
+                                    ptt_track_name: params.ptt_track_name,
+                                    ai_pub_namespace: params.ai_pub_namespace,
+                                    ai_pub_track_name: params.ai_pub_track_name,
+                                    ai_sub_namespace: params.ai_sub_namespace,
+                                    ai_sub_track_name: params.ai_sub_track_name,
+                                });
+                            }
+                        }
+                        write_tlv(mgmt_uart, NetToCtl::Ack, &[]);
+                    } else {
+                        write_tlv(mgmt_uart, NetToCtl::Error, b"save");
+                    }
+                } else {
+                    write_tlv(mgmt_uart, NetToCtl::Error, b"invalid language");
+                }
+            } else {
+                write_tlv(mgmt_uart, NetToCtl::Error, b"utf8");
+            }
+        }
+        CtlToNet::GetChannel => {
+            if let Some(cfg) = storage.parsed_config() {
+                // Find the selected channel (or first)
+                let channel = cfg
+                    .channels
+                    .iter()
+                    .find(|c| c.display_name == storage.selected_channel)
+                    .or_else(|| cfg.channels.first());
+                if let Some(ch) = channel {
+                    let json = format!(
+                        "{{\"id\":\"{}\",\"display_name\":\"{}\"}}",
+                        ch.id, ch.display_name
+                    );
+                    write_tlv(mgmt_uart, NetToCtl::ChannelInfo, json.as_bytes());
+                } else {
+                    write_tlv(mgmt_uart, NetToCtl::Error, b"no channels");
+                }
+            } else {
+                write_tlv(mgmt_uart, NetToCtl::Error, b"no config");
+            }
+        }
+        CtlToNet::SetChannel => {
+            if let Ok(name) = core::str::from_utf8(value) {
+                if let Some(cfg) = storage.parsed_config() {
+                    if cfg.channels.iter().any(|c| c.display_name == name) {
+                        storage.selected_channel = name.to_string();
+                        if storage.save_field(NVS_KEY_SEL_CHANNEL, name).is_ok() {
+                            // Trigger reconfiguration
+                            if let Some(params) = track_params_from_config(
+                                &cfg,
+                                &storage.language,
+                                &storage.selected_channel,
+                            ) {
+                                let _ = moq_cmd_tx.send(MoqCommand::Reconfigure {
+                                    ptt_namespace: params.ptt_namespace,
+                                    ptt_track_name: params.ptt_track_name,
+                                    ai_pub_namespace: params.ai_pub_namespace,
+                                    ai_pub_track_name: params.ai_pub_track_name,
+                                    ai_sub_namespace: params.ai_sub_namespace,
+                                    ai_sub_track_name: params.ai_sub_track_name,
+                                });
+                            }
+                            write_tlv(mgmt_uart, NetToCtl::Ack, &[]);
+                        } else {
+                            write_tlv(mgmt_uart, NetToCtl::Error, b"save");
+                        }
+                    } else {
+                        write_tlv(mgmt_uart, NetToCtl::Error, b"channel not found");
+                    }
+                } else {
+                    write_tlv(mgmt_uart, NetToCtl::Error, b"no config");
+                }
+            } else {
+                write_tlv(mgmt_uart, NetToCtl::Error, b"utf8");
             }
         }
     }

--- a/web-ctl/src/lib.rs
+++ b/web-ctl/src/lib.rs
@@ -507,6 +507,63 @@ impl LinkController {
         Ok(obj.into())
     }
 
+    // ==================== CONFIG / LANGUAGE / CHANNEL ====================
+
+    /// Set the config WebSocket URL on the NET chip.
+    #[wasm_bindgen]
+    pub async fn set_config_url(&mut self, url: &str) -> Result<(), JsValue> {
+        let core = self.core_mut()?;
+        core.set_config_url(url).await.map_err(ctl_error_to_js)
+    }
+
+    /// Set the OAuth access token on the NET chip.
+    #[wasm_bindgen]
+    pub async fn set_access_token(&mut self, token: &str) -> Result<(), JsValue> {
+        let core = self.core_mut()?;
+        core.set_access_token(token).await.map_err(ctl_error_to_js)
+    }
+
+    /// Set the OAuth refresh token on the NET chip.
+    #[wasm_bindgen]
+    pub async fn set_refresh_token(&mut self, token: &str) -> Result<(), JsValue> {
+        let core = self.core_mut()?;
+        core.set_refresh_token(token).await.map_err(ctl_error_to_js)
+    }
+
+    /// Get the current language from the NET chip.
+    #[wasm_bindgen]
+    pub async fn get_language(&mut self) -> Result<String, JsValue> {
+        let core = self.core_mut()?;
+        core.get_language().await.map_err(ctl_error_to_js)
+    }
+
+    /// Set the language on the NET chip.
+    /// Valid values: "en", "de", "es", "hi", "no"
+    #[wasm_bindgen]
+    pub async fn set_language(&mut self, lang: &str) -> Result<(), JsValue> {
+        let core = self.core_mut()?;
+        core.set_language(lang).await.map_err(ctl_error_to_js)
+    }
+
+    /// Get the current channel from the NET chip.
+    /// Returns a JSON object with {id, display_name}.
+    #[wasm_bindgen]
+    pub async fn get_channel(&mut self) -> Result<JsValue, JsValue> {
+        let core = self.core_mut()?;
+        let (id, display_name) = core.get_channel().await.map_err(ctl_error_to_js)?;
+        let obj = js_sys::Object::new();
+        js_sys::Reflect::set(&obj, &"id".into(), &id.into())?;
+        js_sys::Reflect::set(&obj, &"displayName".into(), &display_name.into())?;
+        Ok(obj.into())
+    }
+
+    /// Set the active channel by display name on the NET chip.
+    #[wasm_bindgen]
+    pub async fn set_channel(&mut self, display_name: &str) -> Result<(), JsValue> {
+        let core = self.core_mut()?;
+        core.set_channel(display_name).await.map_err(ctl_error_to_js)
+    }
+
     // ==================== RESET HOLD ====================
 
     /// Hold the UI chip in reset.


### PR DESCRIPTION
## Summary
- Phase 1 of dynamic channel configuration (Issue #1)
- Adds config data model (`DeviceConfig`, `ChannelConfig`, `AiConfig`, `Language`), NVS persistence for credentials/preferences, and 9 new TLV message types for provisioning
- Refactors hardcoded MoQ track setup into parameterized `setup_tracks_from_params()` with `MoqCommand::Reconfigure` for dynamic resubscription
- Grows NVS partition from 24KB to 64KB to accommodate config JSON storage (~20KB)
- Adds CTL CLI subcommands (`config-url`, `access-token`, `refresh-token`, `language`, `channel`), CTL core methods, and web-ctl WASM bindings

## Test plan
- [x] All link crate tests pass (120 tests)
- [x] CTL builds successfully
- [x] web-ctl builds with wasm-pack
- [x] NET firmware builds with ESP-IDF
- [x] Flashed to device and verified all new TLV commands work:
  - `language get` returns "en" (default), `language set de` persists correctly
  - `language set fr` correctly rejected with "invalid language"
  - `config-url set`, `access-token set`, `refresh-token set` all persist
  - `channel get/set` correctly returns "no config" when no config JSON stored

🤖 Generated with [Claude Code](https://claude.com/claude-code)