### PR TITLE
Add board version support via MGMT option bytes

### DIFF
--- a/ctl/src/handlers/mgmt.rs
+++ b/ctl/src/handlers/mgmt.rs
@@ -72,10 +72,6 @@ pub(super) async fn exit_mgmt_bootloader(
         .get_mut()
         .set_baud_rate(link::uart_config::HIGH_SPEED.baudrate)?;
 
-    // Drain any stale data from bootloader and wait for MGMT to be ready
-    core.drain();
-    core.wait_for_mgmt_ready(10).await;
-
     Ok(())
 }
 
@@ -267,9 +263,7 @@ pub async fn handle_mgmt(
 
             match result {
                 Ok(()) => {
-                    // Exit bootloader and reset to user code
-                    exit_mgmt_bootloader(core).await?;
-
+                    // flash_mgmt already does Go + hardware reset + baud rate restore + wait_for_mgmt_ready
                     println!("\nFlash complete!");
                     println!(
                         "The MGMT chip should now be running the new firmware at {} baud.",

--- a/ctl/src/handlers/mgmt.rs
+++ b/ctl/src/handlers/mgmt.rs
@@ -109,7 +109,10 @@ pub async fn handle_mgmt(
     action: MgmtAction,
     core: &mut Core,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let needs_mgmt_firmware = matches!(&action, MgmtAction::Ping { .. } | MgmtAction::Stack { .. });
+    let needs_mgmt_firmware = matches!(
+        &action,
+        MgmtAction::Ping { .. } | MgmtAction::Board | MgmtAction::Stack { .. }
+    );
 
     if needs_mgmt_firmware && !core.wait_for_mgmt_ready(50).await {
         return Err("MGMT chip not responding after reset".into());
@@ -194,6 +197,11 @@ pub async fn handle_mgmt(
             exit_mgmt_bootloader(core).await?;
 
             println!("\nDone!");
+            Ok(())
+        }
+        MgmtAction::Board => {
+            let version = core.mgmt_get_board_version().await?;
+            println!("{}", version);
             Ok(())
         }
         MgmtAction::Version { action } => handle_version(action, core).await,

--- a/ctl/src/handlers/mgmt.rs
+++ b/ctl/src/handlers/mgmt.rs
@@ -1,7 +1,7 @@
 //! MGMT chip command handlers.
 
 use super::Core;
-use crate::{MgmtAction, StackAction};
+use crate::{GetSetU8, MgmtAction, StackAction};
 use indicatif::{ProgressBar, ProgressStyle};
 use link::ctl::SetTimeout;
 use link::ctl::flash::{FlashPhase, MgmtBootloaderEntry};
@@ -13,7 +13,9 @@ use tokio_serial::SerialPort;
 /// Enter MGMT bootloader mode, handling auto-reset and manual fallback.
 ///
 /// Returns whether init should be skipped (true if auto-reset succeeded).
-async fn enter_mgmt_bootloader(core: &mut Core) -> Result<bool, Box<dyn std::error::Error>> {
+pub(super) async fn enter_mgmt_bootloader(
+    core: &mut Core,
+) -> Result<bool, Box<dyn std::error::Error>> {
     // Switch to bootloader baud rate
     println!("Switching to bootloader baud rate (115200)...");
     core.port_mut().get_mut().set_baud_rate(115200)?;
@@ -58,6 +60,49 @@ async fn enter_mgmt_bootloader(core: &mut Core) -> Result<bool, Box<dyn std::err
         .set_timeout(Duration::from_secs(timeouts::NORMAL_SECS));
 
     Ok(skip_init)
+}
+
+pub(super) async fn exit_mgmt_bootloader(
+    core: &mut Core,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let delay_ms = |ms| tokio::time::sleep(Duration::from_millis(ms));
+    core.exit_mgmt_bootloader(delay_ms).await;
+
+    core.port_mut()
+        .get_mut()
+        .set_baud_rate(link::uart_config::HIGH_SPEED.baudrate)?;
+    Ok(())
+}
+
+async fn handle_version(
+    action: Option<GetSetU8>,
+    core: &mut Core,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let skip_init = enter_mgmt_bootloader(core).await?;
+
+    let result = async {
+        match action.unwrap_or_default() {
+            GetSetU8::Get => {
+                let value = core
+                    .get_mgmt_data0_option_byte(skip_init)
+                    .await
+                    .map_err(|e| format!("Failed to read MGMT DATA0 option byte: {:?}", e))?;
+                println!("{}", value);
+            }
+            GetSetU8::Set { value } => {
+                core.set_mgmt_data0_option_byte(skip_init, value)
+                    .await
+                    .map_err(|e| format!("Failed to write MGMT DATA0 option byte: {:?}", e))?;
+                println!("Version set to {}", value);
+            }
+        }
+
+        Ok::<(), Box<dyn std::error::Error>>(())
+    }
+    .await;
+
+    exit_mgmt_bootloader(core).await?;
+    result
 }
 
 pub async fn handle_mgmt(
@@ -142,22 +187,16 @@ pub async fn handle_mgmt(
                 println!("\nFlash Memory: Could not read (read protection may be enabled)");
             }
 
-            // Exit bootloader and reset to user code
-            let delay_ms = |ms| tokio::time::sleep(Duration::from_millis(ms));
-            core.exit_mgmt_bootloader(delay_ms).await;
-
-            // Switch back to normal operation baud rate
             println!(
                 "Switching to normal operation baud rate ({})...",
                 link::uart_config::HIGH_SPEED.baudrate
             );
-            core.port_mut()
-                .get_mut()
-                .set_baud_rate(link::uart_config::HIGH_SPEED.baudrate)?;
+            exit_mgmt_bootloader(core).await?;
 
             println!("\nDone!");
             Ok(())
         }
+        MgmtAction::Version { action } => handle_version(action, core).await,
         MgmtAction::Flash { file } => {
             println!("MGMT Flash");
             println!("==========\n");
@@ -216,8 +255,7 @@ pub async fn handle_mgmt(
             match result {
                 Ok(()) => {
                     // Exit bootloader and reset to user code
-                    let delay_ms = |ms| tokio::time::sleep(Duration::from_millis(ms));
-                    core.exit_mgmt_bootloader(delay_ms).await;
+                    exit_mgmt_bootloader(core).await?;
 
                     println!("\nFlash complete!");
                     println!(

--- a/ctl/src/handlers/mgmt.rs
+++ b/ctl/src/handlers/mgmt.rs
@@ -71,6 +71,11 @@ pub(super) async fn exit_mgmt_bootloader(
     core.port_mut()
         .get_mut()
         .set_baud_rate(link::uart_config::HIGH_SPEED.baudrate)?;
+
+    // Drain any stale data from bootloader and wait for MGMT to be ready
+    core.drain();
+    core.wait_for_mgmt_ready(10).await;
+
     Ok(())
 }
 
@@ -115,7 +120,7 @@ pub async fn handle_mgmt(
     );
 
     if needs_mgmt_firmware && !core.wait_for_mgmt_ready(50).await {
-        return Err("MGMT chip not responding after reset".into());
+        return Err("MGMT chip not responding (timed out)".into());
     }
 
     match action {

--- a/ctl/src/main.rs
+++ b/ctl/src/main.rs
@@ -93,6 +93,11 @@ enum MgmtAction {
     },
     /// Get MGMT chip firmware info
     Info,
+    /// Get or set the MGMT DATA0 version option byte
+    Version {
+        #[command(subcommand)]
+        action: Option<GetSetU8>,
+    },
     /// Flash firmware to the MGMT chip
     Flash { file: std::path::PathBuf },
     /// Stack usage measurement
@@ -243,6 +248,15 @@ enum GetSetU32 {
     Get,
     /// Set a new value
     Set { value: u32 },
+}
+
+#[derive(Debug, Clone, Default, Subcommand)]
+enum GetSetU8 {
+    /// Get the current value
+    #[default]
+    Get,
+    /// Set a new value
+    Set { value: u8 },
 }
 
 #[derive(Debug, Clone, Default, Subcommand)]

--- a/ctl/src/main.rs
+++ b/ctl/src/main.rs
@@ -93,6 +93,8 @@ enum MgmtAction {
     },
     /// Get MGMT chip firmware info
     Info,
+    /// Get the MGMT board version from option bytes
+    Board,
     /// Get or set the MGMT DATA0 version option byte
     Version {
         #[command(subcommand)]

--- a/link/Cargo.toml
+++ b/link/Cargo.toml
@@ -12,7 +12,7 @@ tokio = { version = "1.48.0", features = ["full"] }
 
 [features]
 # Chip module features - each instantiation crate enables only what it needs
-mgmt = []
+mgmt = ["dep:embassy-stm32"]
 ui = []
 net = ["std", "alloc"]
 
@@ -53,6 +53,7 @@ aes-gcm = { version = "0.10", default-features = false, features = ["aes"] }
 hkdf = { version = "0.12", default-features = false }
 sha2 = { version = "0.10", default-features = false }
 embassy-futures = "0.1.2"
+embassy-stm32 = { version = "0.4", optional = true, default-features = false, features = ["stm32f072cb"] }
 md-5 = { version = "0.10", optional = true, default-features = false }
 miniz_oxide = { version = "0.8", optional = true, default-features = false, features = ["with-alloc"] }
 audio-codec-algorithms = { version = "0.7", default-features = false }

--- a/link/src/ctl/core.rs
+++ b/link/src/ctl/core.rs
@@ -514,7 +514,12 @@ impl<P: CtlPort> CtlCore<P> {
             // Use different challenge each time to avoid matching stale responses
             // within this call (across calls, the drain above handles stale data)
             let attempt_byte = attempt as u8;
-            let challenge = [attempt_byte, !attempt_byte, attempt_byte.wrapping_add(1), !attempt_byte.wrapping_add(1)];
+            let challenge = [
+                attempt_byte,
+                !attempt_byte,
+                attempt_byte.wrapping_add(1),
+                !attempt_byte.wrapping_add(1),
+            ];
 
             if self.hello(&challenge).await {
                 // Success! Restore original timeout and return

--- a/link/src/ctl/core.rs
+++ b/link/src/ctl/core.rs
@@ -598,6 +598,25 @@ impl<P: CtlPort> CtlCore<P> {
         StackInfo::from_bytes(&tlv.value).ok_or(CtlError::InvalidData)
     }
 
+    /// Get the MGMT board version from the DATA0 option byte.
+    pub async fn mgmt_get_board_version(&mut self) -> Result<u8, CtlError> {
+        self.write_tlv(CtlToMgmt::GetBoardVersion, &[]).await?;
+        let tlv = self.read_tlv_mgmt().await?;
+        if tlv.tlv_type != MgmtToCtl::BoardVersion {
+            return Err(CtlError::UnexpectedResponse {
+                expected: "BoardVersion",
+                actual: format!("{:?}", tlv.tlv_type),
+            });
+        }
+        if tlv.value.len() != 1 {
+            return Err(CtlError::InvalidLength {
+                expected: 1,
+                actual: tlv.value.len(),
+            });
+        }
+        Ok(tlv.value[0])
+    }
+
     /// Repaint the MGMT chip stack for future measurement.
     pub async fn mgmt_repaint_stack(&mut self) -> Result<(), CtlError> {
         self.write_tlv(CtlToMgmt::RepaintStack, &[]).await?;

--- a/link/src/ctl/core.rs
+++ b/link/src/ctl/core.rs
@@ -9,7 +9,6 @@ use alloc::format;
 use alloc::string::String;
 
 use crate::shared::protocol_config::retries::MAX_TLV_SKIP;
-use crate::shared::timing::bootloader::HELLO_TIMEOUT_MS;
 use crate::shared::timing::reset::ESP32_RESET_HOLD_MS;
 use crate::shared::tlv::{buffer, tunnel};
 use crate::shared::{
@@ -499,16 +498,23 @@ impl<P: CtlPort> CtlCore<P> {
     where
         P: crate::ctl::SetTimeout,
     {
+        // Clear any stale data from previous operations
+        self.drain();
+
         // Save the original timeout so we can restore it when done.
         let original_timeout = self.port.as_ref().map(|p| p.timeout());
 
-        // Set short timeout for hello attempts
+        // Set timeout for hello attempts - longer than bootloader timeout since
+        // MGMT firmware may take a moment to respond after reset
         if let Some(port) = &mut self.port {
-            let _ = port.set_timeout(std::time::Duration::from_millis(HELLO_TIMEOUT_MS));
+            let _ = port.set_timeout(std::time::Duration::from_millis(500));
         }
 
-        for _attempt in 1..=max_attempts {
-            let challenge = [0x12, 0x34, 0x56, 0x78];
+        for attempt in 1..=max_attempts {
+            // Use different challenge each time to avoid matching stale responses
+            // within this call (across calls, the drain above handles stale data)
+            let attempt_byte = attempt as u8;
+            let challenge = [attempt_byte, !attempt_byte, attempt_byte.wrapping_add(1), !attempt_byte.wrapping_add(1)];
 
             if self.hello(&challenge).await {
                 // Success! Restore original timeout and return

--- a/link/src/ctl/flash.rs
+++ b/link/src/ctl/flash.rs
@@ -18,6 +18,9 @@ use espflash::connection::{ClearBufferType, SerialInterface, SerialPortError};
 use std::io::{Error as IoError, ErrorKind};
 use std::time::Duration;
 
+const F072_OPTION_BYTES_BASE: u32 = 0x1FFF_F800;
+const F072_DATA0_BLOCK_ADDR: u32 = F072_OPTION_BYTES_BASE + 0x04;
+
 /// Information retrieved from the MGMT chip when it's in bootloader mode.
 #[derive(Debug, Clone, Default)]
 pub struct MgmtBootloaderInfo {
@@ -611,6 +614,58 @@ pub enum MgmtBootloaderEntry {
 /// These methods require the port to implement `CtlPort<Error = std::io::Error>`.
 /// All I/O is performed through the async `CtlPort` trait.
 impl<P: CtlPort<Error = std::io::Error>> CtlCore<P> {
+    /// Read the MGMT chip's DATA0 option byte.
+    pub async fn get_mgmt_data0_option_byte(
+        &mut self,
+        skip_init: bool,
+    ) -> Result<u8, stm::Error<P::Error>> {
+        if !skip_init {
+            self.drain();
+        }
+
+        let mut bl = Bootloader::new(self.port_mut());
+        if !skip_init {
+            bl.init().await?;
+        }
+
+        let mut data = [0u8; 4];
+        bl.read_memory(F072_DATA0_BLOCK_ADDR, &mut data).await?;
+        Ok(data[0])
+    }
+
+    /// Write the MGMT chip's DATA0 option byte and update its complement.
+    pub async fn set_mgmt_data0_option_byte(
+        &mut self,
+        skip_init: bool,
+        value: u8,
+    ) -> Result<(), stm::Error<P::Error>> {
+        if !skip_init {
+            self.drain();
+        }
+
+        let mut bl = Bootloader::new(self.port_mut());
+        if !skip_init {
+            bl.init().await?;
+        }
+
+        let mut data = [0u8; 4];
+        bl.read_memory(F072_DATA0_BLOCK_ADDR, &mut data).await?;
+        data[0] = value;
+        data[1] = !value;
+        bl.write_memory(F072_DATA0_BLOCK_ADDR, &data).await?;
+
+        let mut verify = [0u8; 4];
+        bl.read_memory(F072_DATA0_BLOCK_ADDR, &mut verify).await?;
+        if verify != data {
+            return Err(stm::Error::Io(IoError::new(
+                ErrorKind::InvalidData,
+                "option byte verification failed",
+            )));
+        }
+
+        Ok(())
+    }
+
     /// Attempt to enter MGMT bootloader mode automatically.
     ///
     /// This implements Strategy 1 for EV15/EV16 detection:

--- a/link/src/ctl/flash.rs
+++ b/link/src/ctl/flash.rs
@@ -20,6 +20,9 @@ use std::time::Duration;
 
 const F072_OPTION_BYTES_BASE: u32 = 0x1FFF_F800;
 const F072_DATA0_BLOCK_ADDR: u32 = F072_OPTION_BYTES_BASE + 0x04;
+const F072_OPTION_BYTES_LEN: usize = 16;
+const F072_DATA0_INDEX: usize = 4;
+const F072_NDATA0_INDEX: usize = 5;
 
 /// Information retrieved from the MGMT chip when it's in bootloader mode.
 #[derive(Debug, Clone, Default)]
@@ -648,18 +651,30 @@ impl<P: CtlPort<Error = std::io::Error>> CtlCore<P> {
             bl.init().await?;
         }
 
-        let mut data = [0u8; 4];
-        bl.read_memory(F072_DATA0_BLOCK_ADDR, &mut data).await?;
-        data[0] = value;
-        data[1] = !value;
-        bl.write_memory(F072_DATA0_BLOCK_ADDR, &data).await?;
+        let mut option_bytes = [0u8; F072_OPTION_BYTES_LEN];
+        bl.read_memory(F072_OPTION_BYTES_BASE, &mut option_bytes)
+            .await?;
+        option_bytes[F072_DATA0_INDEX] = value;
+        option_bytes[F072_NDATA0_INDEX] = !value;
+        bl.write_memory(F072_OPTION_BYTES_BASE, &option_bytes)
+            .await?;
 
-        let mut verify = [0u8; 4];
+        // Option-byte programming may reset the target, so verify with a fresh
+        // bootloader session instead of assuming the current one is still valid.
+        self.drain();
+        let mut bl = Bootloader::new(self.port_mut());
+        bl.init().await?;
+
+        let expected = [value, !value];
+        let mut verify = [0u8; 2];
         bl.read_memory(F072_DATA0_BLOCK_ADDR, &mut verify).await?;
-        if verify != data {
+        if verify != expected {
             return Err(stm::Error::Io(IoError::new(
                 ErrorKind::InvalidData,
-                "option byte verification failed",
+                format!(
+                    "option byte verification failed: expected {:02X?}, got {:02X?}",
+                    expected, verify
+                ),
             )));
         }
 

--- a/link/src/ctl/flash.rs
+++ b/link/src/ctl/flash.rs
@@ -938,12 +938,6 @@ impl<P: CtlPort<Error = std::io::Error>> CtlCore<P> {
             // Jump to new firmware
             bl.go(0x0800_0000).await?;
 
-            // Wait for MGMT to come back online
-            // Try hello() every 100ms, up to 50 attempts (5 seconds total)
-            // This helps avoid the need for retries in UI flashing
-            drop(bl); // Drop bootloader to release port reference
-            let _ = self.wait_for_mgmt_ready(50).await;
-
             Ok(())
         }
         .await;

--- a/link/src/integration_tests.rs
+++ b/link/src/integration_tests.rs
@@ -193,6 +193,14 @@ async fn ctl_mgmt_ping() {
 }
 
 #[tokio::test]
+async fn ctl_mgmt_board_version() {
+    device_test(|mut ctl| async move {
+        assert_eq!(ctl.mgmt_get_board_version().await.unwrap(), 0xFF);
+    })
+    .await;
+}
+
+#[tokio::test]
 async fn ctl_ui_ping() {
     device_test(|mut ctl| async move {
         ctl.ui_ping(b"hello ui").await.unwrap();

--- a/link/src/integration_tests.rs
+++ b/link/src/integration_tests.rs
@@ -7,7 +7,7 @@
 #![cfg(all(feature = "ctl", feature = "mgmt", feature = "net", feature = "ui"))]
 
 use crate::ctl::CtlCore;
-use crate::shared::NoOpStackMonitor;
+use crate::shared::NoOpBoard;
 use crate::shared::mocks::{
     GpioOp, MockAsyncDelay, MockAudioStream, MockButton, MockCtlPort, MockDelay, MockFlash,
     MockPin, TrackingPin, async_async_channel, ctl_async_channel, mock_i2c_with_eeprom,
@@ -55,7 +55,7 @@ where
         ui_reset_pins,
         net_reset_pins,
         MockAsyncDelay,
-        NoOpStackMonitor,
+        NoOpBoard,
     );
 
     // Create WS channels for NET app
@@ -82,7 +82,7 @@ where
             mock_i2c_with_eeprom(),
             MockDelay,
             MockAudioStream::new(),
-            NoOpStackMonitor,
+            NoOpBoard,
         ) => {}
         _ = net::run(
             net_to_mgmt,
@@ -141,7 +141,7 @@ where
         ui_reset_pins,
         net_reset_pins,
         MockAsyncDelay,
-        NoOpStackMonitor,
+        NoOpBoard,
     );
 
     // Create WS channels for NET app
@@ -168,7 +168,7 @@ where
             mock_i2c_with_eeprom(),
             MockDelay,
             MockAudioStream::new(),
-            NoOpStackMonitor,
+            NoOpBoard,
         ) => {}
         _ = net::run(
             net_to_mgmt,
@@ -429,7 +429,7 @@ async fn hello_handshake() {
 async fn mgmt_stack_info() {
     device_test(|mut ctl| async move {
         let info = ctl.mgmt_get_stack_info().await.unwrap();
-        // NoOpStackMonitor returns zeros for everything
+        // NoOpBoard returns zeros for everything
         assert_eq!(info.stack_size, 0);
         assert_eq!(info.stack_used, 0);
     })

--- a/link/src/lib.rs
+++ b/link/src/lib.rs
@@ -30,7 +30,7 @@ pub use shared::{HEADER_SIZE, SYNC_WORD};
 // Re-export uart_config module for chip firmware
 pub use shared::uart_config;
 
-// Re-export StackMonitor trait for mgmt and ui firmware
+// Re-export StackMonitor trait for chip-specific Board traits
 #[cfg(any(feature = "mgmt", feature = "ui"))]
 pub use shared::stack_monitor::StackMonitor;
 

--- a/link/src/mgmt/mod.rs
+++ b/link/src/mgmt/mod.rs
@@ -2,8 +2,8 @@
 
 use crate::info;
 use crate::shared::{
-    Color, CtlToMgmt, CtlToNet, CtlToUi, Led, MgmtToCtl, ReadTlv, StackMonitor, Tlv, Value, WriteTlv,
-    uart_config::SetBaudRate,
+    Color, CtlToMgmt, CtlToNet, CtlToUi, Led, MgmtToCtl, ReadTlv, StackMonitor, Tlv, Value,
+    WriteTlv, uart_config::SetBaudRate,
 };
 use embedded_hal::digital::{OutputPin, StatefulOutputPin};
 use embedded_hal_async::delay::DelayNs;

--- a/link/src/mgmt/mod.rs
+++ b/link/src/mgmt/mod.rs
@@ -9,6 +9,16 @@ use embedded_hal::digital::{OutputPin, StatefulOutputPin};
 use embedded_hal_async::delay::DelayNs;
 use embedded_io_async::{Read, Write};
 
+#[cfg(all(feature = "mgmt", target_arch = "arm", not(test)))]
+fn board_version() -> u8 {
+    embassy_stm32::pac::FLASH.obr().read().data0()
+}
+
+#[cfg(not(all(feature = "mgmt", target_arch = "arm", not(test))))]
+fn board_version() -> u8 {
+    0xFF
+}
+
 /// Holds the GPIO pins used to control the UI chip's reset behavior.
 ///
 /// UI chip boot mode:
@@ -466,6 +476,14 @@ where
                     .must_write_tlv(MgmtToCtl::StackInfo, serialized)
                     .await;
             }
+            BaudRateChange::None
+        }
+        CtlToMgmt::GetBoardVersion => {
+            info!("mgmt: get board version");
+            let version = board_version();
+            to_ctl
+                .must_write_tlv(MgmtToCtl::BoardVersion, &[version])
+                .await;
             BaudRateChange::None
         }
         CtlToMgmt::RepaintStack => {

--- a/link/src/mgmt/mod.rs
+++ b/link/src/mgmt/mod.rs
@@ -2,21 +2,26 @@
 
 use crate::info;
 use crate::shared::{
-    Color, CtlToMgmt, CtlToNet, CtlToUi, Led, MgmtToCtl, ReadTlv, Tlv, Value, WriteTlv,
+    Color, CtlToMgmt, CtlToNet, CtlToUi, Led, MgmtToCtl, ReadTlv, StackMonitor, Tlv, Value, WriteTlv,
     uart_config::SetBaudRate,
 };
 use embedded_hal::digital::{OutputPin, StatefulOutputPin};
 use embedded_hal_async::delay::DelayNs;
 use embedded_io_async::{Read, Write};
 
-#[cfg(all(feature = "mgmt", target_arch = "arm", not(test)))]
-fn board_version() -> u8 {
-    embassy_stm32::pac::FLASH.obr().read().data0()
+/// Board trait for MGMT chip.
+///
+/// Extends StackMonitor with board version reading from option bytes.
+pub trait Board: StackMonitor {
+    /// Get the board version byte from option bytes.
+    fn board_version(&self) -> u8;
 }
 
-#[cfg(not(all(feature = "mgmt", target_arch = "arm", not(test))))]
-fn board_version() -> u8 {
-    0xFF
+#[cfg(test)]
+impl Board for crate::shared::NoOpBoard {
+    fn board_version(&self) -> u8 {
+        0xFF
+    }
 }
 
 /// Holds the GPIO pins used to control the UI chip's reset behavior.
@@ -164,7 +169,7 @@ enum BaudRateChange {
 }
 
 #[allow(unreachable_code)]
-pub async fn run<W, R, RA, GA, BA, RB, GB, BB, UiBoot0, UiBoot1, UiRst, NetBoot, NetRst, D, SM>(
+pub async fn run<W, R, RA, GA, BA, RB, GB, BB, UiBoot0, UiBoot1, UiRst, NetBoot, NetRst, D, B>(
     to_ctl: W,
     mut from_ctl: R,
     mut to_ui: W,
@@ -176,7 +181,7 @@ pub async fn run<W, R, RA, GA, BA, RB, GB, BB, UiBoot0, UiBoot1, UiRst, NetBoot,
     mut ui_reset_pins: UiResetPins<UiBoot0, UiBoot1, UiRst>,
     mut net_reset_pins: NetResetPins<NetBoot, NetRst>,
     mut delay: D,
-    stack_monitor: SM,
+    board: B,
 ) -> !
 where
     W: Write + SetBaudRate,
@@ -191,9 +196,9 @@ where
     UiBoot1: StatefulOutputPin,
     UiRst: StatefulOutputPin,
     NetBoot: OutputPin,
-    SM: crate::shared::StackMonitor,
     NetRst: OutputPin,
     D: DelayNs,
+    B: Board,
 {
     use embassy_sync::{blocking_mutex::raw::NoopRawMutex, mutex::Mutex};
 
@@ -307,7 +312,7 @@ where
                 &mut ui_reset_pins,
                 &mut net_reset_pins,
                 &mut delay,
-                &stack_monitor,
+                &board,
             )
             .await;
 
@@ -335,7 +340,7 @@ where
     unreachable!()
 }
 
-async fn handle_ctl<C, U, N, UiBoot0, UiBoot1, UiRst, NetBoot, NetRst, D, SM>(
+async fn handle_ctl<C, U, N, UiBoot0, UiBoot1, UiRst, NetBoot, NetRst, D, B>(
     tlv: Tlv<CtlToMgmt>,
     to_ctl: &mut C,
     to_ui: &mut U,
@@ -343,7 +348,7 @@ async fn handle_ctl<C, U, N, UiBoot0, UiBoot1, UiRst, NetBoot, NetRst, D, SM>(
     ui_reset_pins: &mut UiResetPins<UiBoot0, UiBoot1, UiRst>,
     net_reset_pins: &mut NetResetPins<NetBoot, NetRst>,
     _delay: &mut D,
-    stack_monitor: &SM,
+    board: &B,
 ) -> BaudRateChange
 where
     C: WriteTlv<MgmtToCtl> + Write + SetBaudRate,
@@ -355,7 +360,7 @@ where
     NetBoot: OutputPin,
     NetRst: OutputPin,
     D: DelayNs,
-    SM: crate::shared::StackMonitor,
+    B: Board,
 {
     match tlv.tlv_type {
         CtlToMgmt::Ping => {
@@ -459,11 +464,11 @@ where
         CtlToMgmt::GetStackInfo => {
             info!("mgmt: get stack info");
             use crate::shared::StackInfo;
-            let range = stack_monitor.stack();
+            let range = board.stack();
             let base = range.end as u32;
             let top = range.start as u32;
-            let size = stack_monitor.stack_size();
-            let used = size.saturating_sub(stack_monitor.stack_painted());
+            let size = board.stack_size();
+            let used = size.saturating_sub(board.stack_painted());
             let info = StackInfo {
                 stack_base: base,
                 stack_top: top,
@@ -480,7 +485,7 @@ where
         }
         CtlToMgmt::GetBoardVersion => {
             info!("mgmt: get board version");
-            let version = board_version();
+            let version = board.board_version();
             to_ctl
                 .must_write_tlv(MgmtToCtl::BoardVersion, &[version])
                 .await;
@@ -488,7 +493,7 @@ where
         }
         CtlToMgmt::RepaintStack => {
             info!("mgmt: repaint stack");
-            stack_monitor.repaint_stack();
+            board.repaint_stack();
             to_ctl.must_write_tlv(MgmtToCtl::Ack, &[]).await;
             BaudRateChange::None
         }

--- a/link/src/shared/mod.rs
+++ b/link/src/shared/mod.rs
@@ -71,10 +71,10 @@ pub use moq::{MAX_MOQ_NAMESPACE_LEN, MAX_MOQ_TRACK_NAME_LEN, MoqError, MoqExampl
 pub use wifi::WifiSsid;
 
 // StackMonitor trait - base for chip-specific Board traits
-#[cfg(any(feature = "mgmt", feature = "ui"))]
-pub use stack_monitor::StackMonitor;
 #[cfg(test)]
 pub use stack_monitor::NoOpBoard;
+#[cfg(any(feature = "mgmt", feature = "ui"))]
+pub use stack_monitor::StackMonitor;
 
 // Re-export embassy_sync types for use by firmware chip modules that need them
 #[cfg(any(feature = "net", feature = "ui"))]

--- a/link/src/shared/mod.rs
+++ b/link/src/shared/mod.rs
@@ -70,12 +70,11 @@ pub use moq::{MAX_MOQ_NAMESPACE_LEN, MAX_MOQ_TRACK_NAME_LEN, MoqError, MoqExampl
 #[allow(unused_imports)] // Re-exported for public API
 pub use wifi::WifiSsid;
 
-// Stack monitor trait - used by mgmt and ui firmware
+// StackMonitor trait - base for chip-specific Board traits
 #[cfg(any(feature = "mgmt", feature = "ui"))]
 pub use stack_monitor::StackMonitor;
-// NoOpStackMonitor is needed for tests
 #[cfg(test)]
-pub use stack_monitor::NoOpStackMonitor;
+pub use stack_monitor::NoOpBoard;
 
 // Re-export embassy_sync types for use by firmware chip modules that need them
 #[cfg(any(feature = "net", feature = "ui"))]

--- a/link/src/shared/protocol.rs
+++ b/link/src/shared/protocol.rs
@@ -139,6 +139,8 @@ pub enum CtlToMgmt {
     SetUiBaudRate,
     /// Get MGMT chip stack usage information
     GetStackInfo,
+    /// Get the board version from MGMT option bytes
+    GetBoardVersion,
     /// Repaint the MGMT chip stack with the paint pattern
     RepaintStack,
 }
@@ -154,6 +156,8 @@ pub enum MgmtToCtl {
     Hello,
     /// Stack usage information (JSON-serialized StackInfo)
     StackInfo,
+    /// Board version from MGMT option bytes (1 byte)
+    BoardVersion,
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, IntoPrimitive, TryFromPrimitive)]

--- a/link/src/shared/stack_monitor.rs
+++ b/link/src/shared/stack_monitor.rs
@@ -1,23 +1,19 @@
-//! Stack monitoring trait abstraction.
+//! Stack info trait abstraction.
 //!
-//! This module provides a trait for stack usage monitoring, allowing
-//! the mgmt and ui modules to work with any stack monitoring implementation
-//! without depending directly on cortex-m-stack.
+//! Provides the base trait for stack monitoring, extended by
+//! chip-specific Board traits in mgmt and ui modules.
 
 use core::ops::Range;
 
-/// Trait for monitoring stack usage.
+/// Trait for stack monitoring operations.
 ///
-/// Implementations typically use platform-specific mechanisms to track
-/// stack usage, such as the `cortex-m-stack` crate for ARM Cortex-M chips.
+/// Base trait extended by chip-specific Board traits.
 pub trait StackMonitor {
     /// Get the stack memory range.
     ///
     /// Returns a range where:
     /// - `start` is the top of the stack (highest address)
     /// - `end` is the base of the stack (lowest address)
-    ///
-    /// Note: For pointer-based ranges, convert to usize using `.start as usize`.
     fn stack(&self) -> Range<*mut u32>;
 
     /// Get the total stack size in bytes.
@@ -26,23 +22,19 @@ pub trait StackMonitor {
     /// Get the amount of stack that has been "painted" (used).
     ///
     /// Stack painting fills unused stack with a known pattern. This
-    /// returns how much of that pattern has been overwritten.
+    /// returns how much of that pattern remains unpainted.
     fn stack_painted(&self) -> u32;
 
     /// Repaint the stack with the pattern for usage tracking.
-    ///
-    /// This should be called periodically to reset the usage tracking.
     fn repaint_stack(&self);
 }
 
-/// No-op stack monitor for platforms without stack monitoring support.
-///
-/// This is used in tests where actual stack monitoring is not needed.
+/// No-op implementation for tests.
 #[cfg(test)]
-pub struct NoOpStackMonitor;
+pub struct NoOpBoard;
 
 #[cfg(test)]
-impl StackMonitor for NoOpStackMonitor {
+impl StackMonitor for NoOpBoard {
     fn stack(&self) -> Range<*mut u32> {
         core::ptr::null_mut()..core::ptr::null_mut()
     }
@@ -55,7 +47,5 @@ impl StackMonitor for NoOpStackMonitor {
         0
     }
 
-    fn repaint_stack(&self) {
-        // No-op
-    }
+    fn repaint_stack(&self) {}
 }

--- a/link/src/ui/mod.rs
+++ b/link/src/ui/mod.rs
@@ -15,8 +15,8 @@ pub use log::{LogMessage, LogSender, MAX_LOG_SIZE};
 
 use crate::info;
 use crate::shared::{
-    Channel, ChannelId, Color, CriticalSectionRawMutex, CtlToUi, Led, NetToUi, Sender, StackMonitor,
-    Tlv, UiLoopbackMode, UiToCtl, UiToNet, WriteTlv, chunk, read_tlv_loop,
+    Channel, ChannelId, Color, CriticalSectionRawMutex, CtlToUi, Led, NetToUi, Sender,
+    StackMonitor, Tlv, UiLoopbackMode, UiToCtl, UiToNet, WriteTlv, chunk, read_tlv_loop,
 };
 
 /// Board trait for UI chip.

--- a/link/src/ui/mod.rs
+++ b/link/src/ui/mod.rs
@@ -15,9 +15,15 @@ pub use log::{LogMessage, LogSender, MAX_LOG_SIZE};
 
 use crate::info;
 use crate::shared::{
-    Channel, ChannelId, Color, CriticalSectionRawMutex, CtlToUi, Led, NetToUi, Sender, Tlv,
-    UiLoopbackMode, UiToCtl, UiToNet, WriteTlv, chunk, read_tlv_loop,
+    Channel, ChannelId, Color, CriticalSectionRawMutex, CtlToUi, Led, NetToUi, Sender, StackMonitor,
+    Tlv, UiLoopbackMode, UiToCtl, UiToNet, WriteTlv, chunk, read_tlv_loop,
 };
+
+/// Board trait for UI chip.
+pub trait Board: StackMonitor {}
+
+#[cfg(test)]
+impl Board for crate::shared::NoOpBoard {}
 use crate::tlv_log;
 use embedded_hal::delay::DelayNs;
 use embedded_hal::digital::StatefulOutputPin;
@@ -46,7 +52,7 @@ enum Event {
 }
 
 #[allow(unreachable_code)]
-pub async fn run<W, R, LR, LG, LB, BA, BB, BM, I, D, AS, SM>(
+pub async fn run<W, R, LR, LG, LB, BA, BB, BM, I, D, AS, B>(
     mut to_mgmt: W,
     from_mgmt: R,
     mut to_net: W,
@@ -58,7 +64,7 @@ pub async fn run<W, R, LR, LG, LB, BA, BB, BM, I, D, AS, SM>(
     mut i2c: I,
     mut delay: D,
     mut audio_system: AS,
-    stack_monitor: SM,
+    board: B,
 ) -> !
 where
     W: Write,
@@ -72,7 +78,7 @@ where
     I: I2c,
     D: DelayNs,
     AS: AudioSystem,
-    SM: crate::shared::StackMonitor,
+    B: Board,
 {
     info!("ui: starting");
 
@@ -134,7 +140,7 @@ where
                         &loopback_mode,
                         &logs_enabled,
                         &mut sframe_state,
-                        &stack_monitor,
+                        &board,
                     )
                     .await
                 }
@@ -372,7 +378,7 @@ async fn button_monitor<'a, B: Wait, const N: usize>(
     }
 }
 
-async fn handle_mgmt<M, N, I, D, SM>(
+async fn handle_mgmt<M, N, I, D, B>(
     tlv: Tlv<CtlToUi>,
     to_mgmt: &mut M,
     to_net: &mut N,
@@ -381,13 +387,13 @@ async fn handle_mgmt<M, N, I, D, SM>(
     loopback_mode: &AtomicU8,
     logs_enabled: &AtomicBool,
     sframe_state: &mut sframe::SFrameState,
-    stack_monitor: &SM,
+    board: &B,
 ) where
     M: WriteTlv<UiToCtl>,
     N: WriteTlv<UiToNet>,
     I: I2c,
     D: DelayNs,
-    SM: crate::shared::StackMonitor,
+    B: Board,
 {
     match tlv.tlv_type {
         CtlToUi::Ping => {
@@ -470,11 +476,11 @@ async fn handle_mgmt<M, N, I, D, SM>(
         CtlToUi::GetStackInfo => {
             info!("ui: get stack info");
             use crate::shared::StackInfo;
-            let range = stack_monitor.stack();
+            let range = board.stack();
             let base = range.end as u32;
             let top = range.start as u32;
-            let size = stack_monitor.stack_size();
-            let used = size.saturating_sub(stack_monitor.stack_painted());
+            let size = board.stack_size();
+            let used = size.saturating_sub(board.stack_painted());
             let info = StackInfo {
                 stack_base: base,
                 stack_top: top,
@@ -488,7 +494,7 @@ async fn handle_mgmt<M, N, I, D, SM>(
         }
         CtlToUi::RepaintStack => {
             info!("ui: repaint stack");
-            stack_monitor.repaint_stack();
+            board.repaint_stack();
             to_mgmt.must_write_tlv(UiToCtl::Ack, &[]).await;
         }
         CtlToUi::GetLogsEnabled => {
@@ -613,7 +619,7 @@ mod tests {
             &loopback_mode,
             &logs_enabled,
             &mut sframe_state,
-            &crate::shared::NoOpStackMonitor,
+            &crate::shared::NoOpBoard,
         )
         .await;
 
@@ -650,7 +656,7 @@ mod tests {
             &loopback_mode,
             &logs_enabled,
             &mut sframe_state,
-            &crate::shared::NoOpStackMonitor,
+            &crate::shared::NoOpBoard,
         )
         .await;
 
@@ -693,7 +699,7 @@ mod tests {
             &loopback_mode,
             &logs_enabled,
             &mut sframe_state,
-            &crate::shared::NoOpStackMonitor,
+            &crate::shared::NoOpBoard,
         )
         .await;
 
@@ -733,7 +739,7 @@ mod tests {
             &loopback_mode,
             &logs_enabled,
             &mut sframe_state,
-            &crate::shared::NoOpStackMonitor,
+            &crate::shared::NoOpBoard,
         )
         .await;
 
@@ -771,7 +777,7 @@ mod tests {
             &loopback_mode,
             &logs_enabled,
             &mut sframe_state,
-            &crate::shared::NoOpStackMonitor,
+            &crate::shared::NoOpBoard,
         )
         .await;
 
@@ -809,7 +815,7 @@ mod tests {
             &loopback_mode,
             &logs_enabled,
             &mut sframe_state,
-            &crate::shared::NoOpStackMonitor,
+            &crate::shared::NoOpBoard,
         )
         .await;
 
@@ -824,7 +830,7 @@ mod tests {
 #[cfg(test)]
 mod audio_streaming_tests {
     use super::*;
-    use crate::shared::NoOpStackMonitor;
+    use crate::shared::NoOpBoard;
     use crate::shared::ReadTlv;
     use crate::shared::mocks::{
         ControllableButton, MockAudioStream, MockButton, MockDelay, mock_i2c_with_eeprom,
@@ -918,7 +924,7 @@ mod audio_streaming_tests {
                 mock_i2c_with_eeprom(),
                 MockDelay,
                 MockAudioStream::new(),
-                NoOpStackMonitor,
+                NoOpBoard,
             ) => unreachable!(),
             _ = collector.collect_from(net_from_ui) => unreachable!(),
             _ = async {
@@ -985,7 +991,7 @@ mod audio_streaming_tests {
                 mock_i2c_with_eeprom(),
                 MockDelay,
                 MockAudioStream::new(),
-                NoOpStackMonitor,
+                NoOpBoard,
             ) => unreachable!(),
             _ = collector.collect_from(net_from_ui) => unreachable!(),
             _ = async {
@@ -1047,7 +1053,7 @@ mod audio_streaming_tests {
                 mock_i2c_with_eeprom(),
                 MockDelay,
                 MockAudioStream::new(),
-                NoOpStackMonitor,
+                NoOpBoard,
             ) => unreachable!(),
             _ = collector.collect_from(net_from_ui) => unreachable!(),
             _ = async {
@@ -1112,7 +1118,7 @@ mod audio_streaming_tests {
                 mock_i2c_with_eeprom(),
                 MockDelay,
                 MockAudioStream::new(),
-                NoOpStackMonitor,
+                NoOpBoard,
             ) => unreachable!(),
             _ = collector.collect_from(net_from_ui) => unreachable!(),
             _ = async {
@@ -1151,7 +1157,7 @@ mod audio_streaming_tests {
                 mock_i2c_with_eeprom(),
                 MockDelay,
                 MockAudioStream::new(),
-                NoOpStackMonitor,
+                NoOpBoard,
             ) => unreachable!(),
             _ = collector.collect_from(net_from_ui) => unreachable!(),
             _ = async {
@@ -1206,7 +1212,7 @@ mod audio_streaming_tests {
                 mock_i2c_with_eeprom(),
                 MockDelay,
                 MockAudioStream::new(),
-                NoOpStackMonitor,
+                NoOpBoard,
             ) => unreachable!(),
             _ = collector.collect_from(net_from_ui) => unreachable!(),
             _ = async {
@@ -1302,7 +1308,7 @@ mod audio_streaming_tests {
                 mock_i2c_with_eeprom(),
                 MockDelay,
                 audio_stream,
-                NoOpStackMonitor,
+                NoOpBoard,
             ) => unreachable!(),
             _ = async {
                 // Wait for startup tone to complete (50 frames × 5ms = 250ms)
@@ -1397,7 +1403,7 @@ mod audio_streaming_tests {
                 mock_i2c_with_eeprom(),
                 MockDelay,
                 audio_stream,
-                NoOpStackMonitor,
+                NoOpBoard,
             ) => unreachable!(),
             _ = async {
                 // Wait for startup tone to complete (50 frames × 5ms = 250ms)

--- a/mgmt/Cargo.toml
+++ b/mgmt/Cargo.toml
@@ -12,7 +12,7 @@ defmt = "1"
 defmt-rtt = "1"
 
 embassy-executor = { version = "0.9", features = ["arch-cortex-m", "executor-thread", "executor-interrupt", "defmt"] }
-embassy-stm32 = { version = "0.4", features = ["defmt", "stm32f072cb", "memory-x", "exti", "chrono", "time-driver-any"] }
+embassy-stm32 = { version = "0.4", features = ["defmt", "stm32f072cb", "memory-x", "exti", "chrono", "time-driver-any", "unstable-pac"] }
 embassy-sync = { version = "0.7", features = ["defmt"] }
 embassy-time = { version = "0.5", features = ["defmt"] }
 heapless = "0.8"
@@ -27,6 +27,7 @@ cortex-m-stack = "0.2.1"
 
 [profile.dev]
 opt-level = "s"
+lto = "fat"
 
 [profile.release]
 debug = 2

--- a/mgmt/src/main.rs
+++ b/mgmt/src/main.rs
@@ -15,7 +15,7 @@ use embassy_stm32::{
 };
 use embassy_time::Delay;
 use embedded_io_async::{ErrorType, Read, Write};
-use link::{uart_config::SetBaudRate, StackMonitor, mgmt::Board};
+use link::{mgmt::Board, uart_config::SetBaudRate, StackMonitor};
 use {defmt_rtt as _, panic_probe as _};
 
 #[derive(Copy, Clone)]
@@ -183,27 +183,21 @@ fn setup_common(
     let ui_rx_buf = singleton!(: [u8; DMA_BUF_SIZE] = [0; DMA_BUF_SIZE]).unwrap();
     let net_rx_buf = singleton!(: [u8; DMA_BUF_SIZE] = [0; DMA_BUF_SIZE]).unwrap();
 
-    let (to_ctl, from_ctl) = Uart::new(
-        usart1, pa10, pa9, Irqs, dma1_ch2, dma1_ch3, ctl_config,
-    )
-    .unwrap()
-    .split();
+    let (to_ctl, from_ctl) = Uart::new(usart1, pa10, pa9, Irqs, dma1_ch2, dma1_ch3, ctl_config)
+        .unwrap()
+        .split();
     let to_ctl = UartTxWrapper(to_ctl);
     let from_ctl = UartRxWrapper(from_ctl.into_ring_buffered(ctl_rx_buf));
 
-    let (to_ui, from_ui) = Uart::new(
-        usart2, pa3, pa2, Irqs, dma1_ch4, dma1_ch5, ui_config,
-    )
-    .unwrap()
-    .split();
+    let (to_ui, from_ui) = Uart::new(usart2, pa3, pa2, Irqs, dma1_ch4, dma1_ch5, ui_config)
+        .unwrap()
+        .split();
     let to_ui = UartTxWrapper(to_ui);
     let from_ui = UartRxWrapper(from_ui.into_ring_buffered(ui_rx_buf));
 
-    let (to_net, from_net) = Uart::new(
-        usart3, pb11, pb10, Irqs, dma1_ch7, dma1_ch6, net_config,
-    )
-    .unwrap()
-    .split();
+    let (to_net, from_net) = Uart::new(usart3, pb11, pb10, Irqs, dma1_ch7, dma1_ch6, net_config)
+        .unwrap()
+        .split();
     let to_net = UartTxWrapper(to_net);
     let from_net = UartRxWrapper(from_net.into_ring_buffered(net_rx_buf));
 
@@ -213,17 +207,24 @@ fn setup_common(
     let ui_rst = Output::new(pb3, Level::Low, Speed::Low);
     let ui_reset_pins = link::mgmt::UiResetPins::new(ui_boot0, ui_boot1, ui_rst);
 
-    (mco, to_ctl, from_ctl, to_ui, from_ui, to_net, from_net, ui_reset_pins)
+    (
+        mco,
+        to_ctl,
+        from_ctl,
+        to_ui,
+        from_ui,
+        to_net,
+        from_net,
+        ui_reset_pins,
+    )
 }
 
 #[allow(dead_code)]
 async fn run_ev16(p: embassy_stm32::Peripherals) -> ! {
     let (_mco, to_ctl, from_ctl, to_ui, from_ui, to_net, from_net, ui_reset_pins) = setup_common(
-        p.MCO, p.PA8,
-        p.USART1, p.USART2, p.USART3,
-        p.PA9, p.PA10, p.PA2, p.PA3, p.PB10, p.PB11,
-        p.DMA1_CH2, p.DMA1_CH3, p.DMA1_CH4, p.DMA1_CH5, p.DMA1_CH6, p.DMA1_CH7,
-        p.PA15, p.PB3, p.PB8,
+        p.MCO, p.PA8, p.USART1, p.USART2, p.USART3, p.PA9, p.PA10, p.PA2, p.PA3, p.PB10, p.PB11,
+        p.DMA1_CH2, p.DMA1_CH3, p.DMA1_CH4, p.DMA1_CH5, p.DMA1_CH6, p.DMA1_CH7, p.PA15, p.PB3,
+        p.PB8,
     );
 
     // EV16 LED A: R=PA4 (inverted), G=PA6, B=PA7
@@ -246,19 +247,27 @@ async fn run_ev16(p: embassy_stm32::Peripherals) -> ! {
     let net_reset_pins = link::mgmt::NetResetPins::new(net_boot, net_rst);
 
     link::mgmt::run(
-        to_ctl, from_ctl, to_ui, from_ui, to_net, from_net,
-        led_a, led_b, ui_reset_pins, net_reset_pins, Delay, Stm32Board,
+        to_ctl,
+        from_ctl,
+        to_ui,
+        from_ui,
+        to_net,
+        from_net,
+        led_a,
+        led_b,
+        ui_reset_pins,
+        net_reset_pins,
+        Delay,
+        Stm32Board,
     )
     .await;
 }
 
 async fn run_ev17(p: embassy_stm32::Peripherals) -> ! {
     let (_mco, to_ctl, from_ctl, to_ui, from_ui, to_net, from_net, ui_reset_pins) = setup_common(
-        p.MCO, p.PA8,
-        p.USART1, p.USART2, p.USART3,
-        p.PA9, p.PA10, p.PA2, p.PA3, p.PB10, p.PB11,
-        p.DMA1_CH2, p.DMA1_CH3, p.DMA1_CH4, p.DMA1_CH5, p.DMA1_CH6, p.DMA1_CH7,
-        p.PA15, p.PB3, p.PB8,
+        p.MCO, p.PA8, p.USART1, p.USART2, p.USART3, p.PA9, p.PA10, p.PA2, p.PA3, p.PB10, p.PB11,
+        p.DMA1_CH2, p.DMA1_CH3, p.DMA1_CH4, p.DMA1_CH5, p.DMA1_CH6, p.DMA1_CH7, p.PA15, p.PB3,
+        p.PB8,
     );
 
     // EV17 board updates:
@@ -282,8 +291,18 @@ async fn run_ev17(p: embassy_stm32::Peripherals) -> ! {
     let net_reset_pins = link::mgmt::NetResetPins::new(net_boot, net_rst);
 
     link::mgmt::run(
-        to_ctl, from_ctl, to_ui, from_ui, to_net, from_net,
-        led_a, led_b, ui_reset_pins, net_reset_pins, Delay, Stm32Board,
+        to_ctl,
+        from_ctl,
+        to_ui,
+        from_ui,
+        to_net,
+        from_net,
+        led_a,
+        led_b,
+        ui_reset_pins,
+        net_reset_pins,
+        Delay,
+        Stm32Board,
     )
     .await;
 }
@@ -326,6 +345,6 @@ async fn main(_spawner: Spawner) {
     match Stm32Board.board_version() {
         16 => run_ev16(p).await,
         17 => run_ev17(p).await,
-        _ => loop {}
+        _ => loop {},
     }
 }

--- a/mgmt/src/main.rs
+++ b/mgmt/src/main.rs
@@ -140,10 +140,40 @@ bind_interrupts!(struct Irqs {
     USART3_4 => usart::InterruptHandler<peripherals::USART3>;
 });
 
-#[allow(dead_code)]
-async fn run_ev16(p: embassy_stm32::Peripherals) -> ! {
+/// Common peripheral setup: MCO clock output, UARTs, and UI reset pins.
+fn setup_common(
+    mco: embassy_stm32::Peri<'static, peripherals::MCO>,
+    pa8: embassy_stm32::Peri<'static, peripherals::PA8>,
+    usart1: embassy_stm32::Peri<'static, peripherals::USART1>,
+    usart2: embassy_stm32::Peri<'static, peripherals::USART2>,
+    usart3: embassy_stm32::Peri<'static, peripherals::USART3>,
+    pa9: embassy_stm32::Peri<'static, peripherals::PA9>,
+    pa10: embassy_stm32::Peri<'static, peripherals::PA10>,
+    pa2: embassy_stm32::Peri<'static, peripherals::PA2>,
+    pa3: embassy_stm32::Peri<'static, peripherals::PA3>,
+    pb10: embassy_stm32::Peri<'static, peripherals::PB10>,
+    pb11: embassy_stm32::Peri<'static, peripherals::PB11>,
+    dma1_ch2: embassy_stm32::Peri<'static, peripherals::DMA1_CH2>,
+    dma1_ch3: embassy_stm32::Peri<'static, peripherals::DMA1_CH3>,
+    dma1_ch4: embassy_stm32::Peri<'static, peripherals::DMA1_CH4>,
+    dma1_ch5: embassy_stm32::Peri<'static, peripherals::DMA1_CH5>,
+    dma1_ch6: embassy_stm32::Peri<'static, peripherals::DMA1_CH6>,
+    dma1_ch7: embassy_stm32::Peri<'static, peripherals::DMA1_CH7>,
+    pa15: embassy_stm32::Peri<'static, peripherals::PA15>,
+    pb3: embassy_stm32::Peri<'static, peripherals::PB3>,
+    pb8: embassy_stm32::Peri<'static, peripherals::PB8>,
+) -> (
+    Mco<'static, peripherals::MCO>,
+    UartTxWrapper<'static>,
+    UartRxWrapper<'static>,
+    UartTxWrapper<'static>,
+    UartRxWrapper<'static>,
+    UartTxWrapper<'static>,
+    UartRxWrapper<'static>,
+    link::mgmt::UiResetPins<Output<'static>, Output<'static>, Output<'static>>,
+) {
     // MCO on PA8: Output 6 MHz clock for UI chip
-    let _mco = Mco::new(p.MCO, p.PA8, McoSource::PLL, McoPrescaler::DIV4);
+    let mco = Mco::new(mco, pa8, McoSource::PLL, McoPrescaler::DIV4);
 
     let ctl_config = uart_config_to_stm32(link::uart_config::CTL_MGMT);
     let ui_config = uart_config_to_stm32(link::uart_config::MGMT_UI);
@@ -154,7 +184,7 @@ async fn run_ev16(p: embassy_stm32::Peripherals) -> ! {
     let net_rx_buf = singleton!(: [u8; DMA_BUF_SIZE] = [0; DMA_BUF_SIZE]).unwrap();
 
     let (to_ctl, from_ctl) = Uart::new(
-        p.USART1, p.PA10, p.PA9, Irqs, p.DMA1_CH2, p.DMA1_CH3, ctl_config,
+        usart1, pa10, pa9, Irqs, dma1_ch2, dma1_ch3, ctl_config,
     )
     .unwrap()
     .split();
@@ -162,7 +192,7 @@ async fn run_ev16(p: embassy_stm32::Peripherals) -> ! {
     let from_ctl = UartRxWrapper(from_ctl.into_ring_buffered(ctl_rx_buf));
 
     let (to_ui, from_ui) = Uart::new(
-        p.USART2, p.PA3, p.PA2, Irqs, p.DMA1_CH4, p.DMA1_CH5, ui_config,
+        usart2, pa3, pa2, Irqs, dma1_ch4, dma1_ch5, ui_config,
     )
     .unwrap()
     .split();
@@ -170,12 +200,31 @@ async fn run_ev16(p: embassy_stm32::Peripherals) -> ! {
     let from_ui = UartRxWrapper(from_ui.into_ring_buffered(ui_rx_buf));
 
     let (to_net, from_net) = Uart::new(
-        p.USART3, p.PB11, p.PB10, Irqs, p.DMA1_CH7, p.DMA1_CH6, net_config,
+        usart3, pb11, pb10, Irqs, dma1_ch7, dma1_ch6, net_config,
     )
     .unwrap()
     .split();
     let to_net = UartTxWrapper(to_net);
     let from_net = UartRxWrapper(from_net.into_ring_buffered(net_rx_buf));
+
+    // UI reset pins (directly under MGMT control)
+    let ui_boot0 = Output::new(pa15, Level::Low, Speed::Low);
+    let ui_boot1 = Output::new(pb8, Level::High, Speed::Low);
+    let ui_rst = Output::new(pb3, Level::Low, Speed::Low);
+    let ui_reset_pins = link::mgmt::UiResetPins::new(ui_boot0, ui_boot1, ui_rst);
+
+    (mco, to_ctl, from_ctl, to_ui, from_ui, to_net, from_net, ui_reset_pins)
+}
+
+#[allow(dead_code)]
+async fn run_ev16(p: embassy_stm32::Peripherals) -> ! {
+    let (_mco, to_ctl, from_ctl, to_ui, from_ui, to_net, from_net, ui_reset_pins) = setup_common(
+        p.MCO, p.PA8,
+        p.USART1, p.USART2, p.USART3,
+        p.PA9, p.PA10, p.PA2, p.PA3, p.PB10, p.PB11,
+        p.DMA1_CH2, p.DMA1_CH3, p.DMA1_CH4, p.DMA1_CH5, p.DMA1_CH6, p.DMA1_CH7,
+        p.PA15, p.PB3, p.PB8,
+    );
 
     // EV16 LED A: R=PA4 (inverted), G=PA6, B=PA7
     let led_a = (
@@ -191,66 +240,31 @@ async fn run_ev16(p: embassy_stm32::Peripherals) -> ! {
         Output::new(p.PB15, Level::Low, Speed::Low),
     );
 
-    let ui_boot0 = Output::new(p.PA15, Level::Low, Speed::Low);
-    let ui_boot1 = Output::new(p.PB8, Level::High, Speed::Low);
-    let ui_rst = Output::new(p.PB3, Level::Low, Speed::Low);
-    let ui_reset_pins = link::mgmt::UiResetPins::new(ui_boot0, ui_boot1, ui_rst);
-
+    // EV16 NET reset: BOOT=PB5, RST=PB4
     let net_boot = Output::new(p.PB5, Level::High, Speed::Low);
     let net_rst = Output::new(p.PB4, Level::Low, Speed::Low);
     let net_reset_pins = link::mgmt::NetResetPins::new(net_boot, net_rst);
 
     link::mgmt::run(
-        to_ctl,
-        from_ctl,
-        to_ui,
-        from_ui,
-        to_net,
-        from_net,
-        led_a,
-        led_b,
-        ui_reset_pins,
-        net_reset_pins,
-        Delay,
-        Stm32Board,
+        to_ctl, from_ctl, to_ui, from_ui, to_net, from_net,
+        led_a, led_b, ui_reset_pins, net_reset_pins, Delay, Stm32Board,
     )
     .await;
 }
+
 async fn run_ev17(p: embassy_stm32::Peripherals) -> ! {
-    // MCO on PA8: Output 6 MHz clock for UI chip
-    let _mco = Mco::new(p.MCO, p.PA8, McoSource::PLL, McoPrescaler::DIV4);
+    let (_mco, to_ctl, from_ctl, to_ui, from_ui, to_net, from_net, ui_reset_pins) = setup_common(
+        p.MCO, p.PA8,
+        p.USART1, p.USART2, p.USART3,
+        p.PA9, p.PA10, p.PA2, p.PA3, p.PB10, p.PB11,
+        p.DMA1_CH2, p.DMA1_CH3, p.DMA1_CH4, p.DMA1_CH5, p.DMA1_CH6, p.DMA1_CH7,
+        p.PA15, p.PB3, p.PB8,
+    );
 
-    let ctl_config = uart_config_to_stm32(link::uart_config::CTL_MGMT);
-    let ui_config = uart_config_to_stm32(link::uart_config::MGMT_UI);
-    let net_config = uart_config_to_stm32(link::uart_config::MGMT_NET);
-
-    let ctl_rx_buf = singleton!(: [u8; DMA_BUF_SIZE] = [0; DMA_BUF_SIZE]).unwrap();
-    let ui_rx_buf = singleton!(: [u8; DMA_BUF_SIZE] = [0; DMA_BUF_SIZE]).unwrap();
-    let net_rx_buf = singleton!(: [u8; DMA_BUF_SIZE] = [0; DMA_BUF_SIZE]).unwrap();
-
-    let (to_ctl, from_ctl) = Uart::new(
-        p.USART1, p.PA10, p.PA9, Irqs, p.DMA1_CH2, p.DMA1_CH3, ctl_config,
-    )
-    .unwrap()
-    .split();
-    let to_ctl = UartTxWrapper(to_ctl);
-    let from_ctl = UartRxWrapper(from_ctl.into_ring_buffered(ctl_rx_buf));
-
-    let (to_ui, from_ui) = Uart::new(
-        p.USART2, p.PA3, p.PA2, Irqs, p.DMA1_CH4, p.DMA1_CH5, ui_config,
-    )
-    .unwrap()
-    .split();
-    let to_ui = UartTxWrapper(to_ui);
-    let from_ui = UartRxWrapper(from_ui.into_ring_buffered(ui_rx_buf));
-
-    let (to_net, from_net) = Uart::new(
-        p.USART3, p.PB11, p.PB10, Irqs, p.DMA1_CH7, p.DMA1_CH6, net_config,
-    )
-    .unwrap()
-    .split();
-    let to_net = UartTxWrapper(to_net);
-    let from_net = UartRxWrapper(from_net.into_ring_buffered(net_rx_buf));
+    // EV17 board updates:
+    // - PB0 is BATTERY_MON (ADC input)
+    // - PC14 is MGMT_DEBUG1 (output)
+    // - PB15 is NC (floating)
 
     // EV17 LED A: R=PB5, G=PB4, B=PB1
     let led_a = (
@@ -259,39 +273,17 @@ async fn run_ev17(p: embassy_stm32::Peripherals) -> ! {
         Output::new(p.PB1, Level::Low, Speed::Low),
     );
 
-    // EV17 board updates:
-    // - PB0 is BATTERY_MON (ADC input)
-    // - PC14 is MGMT_DEBUG1 (output)
-    // - PB15 is NC (floating)
-    // let _battery_mon = Input::new(p.PB0, Pull::None);
-    // let _mgmt_debug1 = Output::new(p.PC14, Level::Low, Speed::Low);
-    // let _pb15_nc = Input::new(p.PB15, Pull::None);
-
-    // LED B no longer exists on EV17.
+    // LED B no longer exists on EV17
     let led_b = (NoopOutputPin, NoopOutputPin, NoopOutputPin);
 
-    let ui_boot0 = Output::new(p.PA15, Level::Low, Speed::Low);
-    let ui_boot1 = Output::new(p.PB8, Level::High, Speed::Low);
-    let ui_rst = Output::new(p.PB3, Level::Low, Speed::Low);
-    let ui_reset_pins = link::mgmt::UiResetPins::new(ui_boot0, ui_boot1, ui_rst);
-
+    // EV17 NET reset: BOOT=PB6, RST=PC13
     let net_boot = Output::new(p.PB6, Level::High, Speed::Low);
     let net_rst = Output::new(p.PC13, Level::Low, Speed::Low);
     let net_reset_pins = link::mgmt::NetResetPins::new(net_boot, net_rst);
 
     link::mgmt::run(
-        to_ctl,
-        from_ctl,
-        to_ui,
-        from_ui,
-        to_net,
-        from_net,
-        led_a,
-        led_b,
-        ui_reset_pins,
-        net_reset_pins,
-        Delay,
-        Stm32Board,
+        to_ctl, from_ctl, to_ui, from_ui, to_net, from_net,
+        led_a, led_b, ui_reset_pins, net_reset_pins, Delay, Stm32Board,
     )
     .await;
 }
@@ -335,7 +327,5 @@ async fn main(_spawner: Spawner) {
         16 => run_ev16(p).await,
         17 => run_ev17(p).await,
         _ => loop {}
-        // _ => run_ev17(p).await,
     }
 }
-

--- a/mgmt/src/main.rs
+++ b/mgmt/src/main.rs
@@ -18,10 +18,37 @@ use embedded_io_async::{ErrorType, Read, Write};
 use link::uart_config::SetBaudRate;
 use {defmt_rtt as _, panic_probe as _};
 
-/// Stack monitor implementation using cortex-m-stack.
-struct CortexMStackMonitor;
+#[derive(Copy, Clone)]
+struct NoopOutputPin;
 
-impl link::StackMonitor for CortexMStackMonitor {
+impl embedded_hal::digital::ErrorType for NoopOutputPin {
+    type Error = core::convert::Infallible;
+}
+
+impl embedded_hal::digital::OutputPin for NoopOutputPin {
+    fn set_low(&mut self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    fn set_high(&mut self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+}
+
+impl embedded_hal::digital::StatefulOutputPin for NoopOutputPin {
+    fn is_set_high(&mut self) -> Result<bool, Self::Error> {
+        Ok(false)
+    }
+
+    fn is_set_low(&mut self) -> Result<bool, Self::Error> {
+        Ok(true)
+    }
+}
+
+/// Board implementation for MGMT STM32.
+struct Stm32Board;
+
+impl link::StackMonitor for Stm32Board {
     fn stack(&self) -> core::ops::Range<*mut u32> {
         cortex_m_stack::stack()
     }
@@ -36,6 +63,12 @@ impl link::StackMonitor for CortexMStackMonitor {
 
     fn repaint_stack(&self) {
         cortex_m_stack::repaint_stack();
+    }
+}
+
+impl link::mgmt::Board for Stm32Board {
+    fn board_version(&self) -> u8 {
+        embassy_stm32::pac::FLASH.obr().read().data0()
     }
 }
 
@@ -107,6 +140,162 @@ bind_interrupts!(struct Irqs {
     USART3_4 => usart::InterruptHandler<peripherals::USART3>;
 });
 
+#[allow(dead_code)]
+async fn ev16_pin_assignments_init(p: embassy_stm32::Peripherals) -> ! {
+    // MCO on PA8: Output 6 MHz clock for UI chip
+    let _mco = Mco::new(p.MCO, p.PA8, McoSource::PLL, McoPrescaler::DIV4);
+
+    let ctl_config = uart_config_to_stm32(link::uart_config::CTL_MGMT);
+    let ui_config = uart_config_to_stm32(link::uart_config::MGMT_UI);
+    let net_config = uart_config_to_stm32(link::uart_config::MGMT_NET);
+
+    let ctl_rx_buf = singleton!(: [u8; DMA_BUF_SIZE] = [0; DMA_BUF_SIZE]).unwrap();
+    let ui_rx_buf = singleton!(: [u8; DMA_BUF_SIZE] = [0; DMA_BUF_SIZE]).unwrap();
+    let net_rx_buf = singleton!(: [u8; DMA_BUF_SIZE] = [0; DMA_BUF_SIZE]).unwrap();
+
+    let (to_ctl, from_ctl) = Uart::new(
+        p.USART1, p.PA10, p.PA9, Irqs, p.DMA1_CH2, p.DMA1_CH3, ctl_config,
+    )
+    .unwrap()
+    .split();
+    let to_ctl = UartTxWrapper(to_ctl);
+    let from_ctl = UartRxWrapper(from_ctl.into_ring_buffered(ctl_rx_buf));
+
+    let (to_ui, from_ui) = Uart::new(
+        p.USART2, p.PA3, p.PA2, Irqs, p.DMA1_CH4, p.DMA1_CH5, ui_config,
+    )
+    .unwrap()
+    .split();
+    let to_ui = UartTxWrapper(to_ui);
+    let from_ui = UartRxWrapper(from_ui.into_ring_buffered(ui_rx_buf));
+
+    let (to_net, from_net) = Uart::new(
+        p.USART3, p.PB11, p.PB10, Irqs, p.DMA1_CH7, p.DMA1_CH6, net_config,
+    )
+    .unwrap()
+    .split();
+    let to_net = UartTxWrapper(to_net);
+    let from_net = UartRxWrapper(from_net.into_ring_buffered(net_rx_buf));
+
+    // EV16 LED A: R=PA4 (inverted), G=PA6, B=PA7
+    let led_a = (
+        link::InvertedPin(Output::new(p.PA4, Level::Low, Speed::Low)),
+        Output::new(p.PA6, Level::Low, Speed::Low),
+        Output::new(p.PA7, Level::Low, Speed::Low),
+    );
+
+    // EV16 LED B: R=PB0, G=PB6, B=PB15
+    let led_b = (
+        Output::new(p.PB0, Level::Low, Speed::Low),
+        Output::new(p.PB6, Level::Low, Speed::Low),
+        Output::new(p.PB15, Level::Low, Speed::Low),
+    );
+
+    let ui_boot0 = Output::new(p.PA15, Level::Low, Speed::Low);
+    let ui_boot1 = Output::new(p.PB8, Level::High, Speed::Low);
+    let ui_rst = Output::new(p.PB3, Level::Low, Speed::Low);
+    let ui_reset_pins = link::mgmt::UiResetPins::new(ui_boot0, ui_boot1, ui_rst);
+
+    let net_boot = Output::new(p.PB5, Level::High, Speed::Low);
+    let net_rst = Output::new(p.PB4, Level::Low, Speed::Low);
+    let net_reset_pins = link::mgmt::NetResetPins::new(net_boot, net_rst);
+
+    link::mgmt::run(
+        to_ctl,
+        from_ctl,
+        to_ui,
+        from_ui,
+        to_net,
+        from_net,
+        led_a,
+        led_b,
+        ui_reset_pins,
+        net_reset_pins,
+        Delay,
+        Stm32Board,
+    )
+    .await;
+}
+async fn ev17_pin_assignments_init(p: embassy_stm32::Peripherals) -> ! {
+    // MCO on PA8: Output 6 MHz clock for UI chip
+    let _mco = Mco::new(p.MCO, p.PA8, McoSource::PLL, McoPrescaler::DIV4);
+
+    let ctl_config = uart_config_to_stm32(link::uart_config::CTL_MGMT);
+    let ui_config = uart_config_to_stm32(link::uart_config::MGMT_UI);
+    let net_config = uart_config_to_stm32(link::uart_config::MGMT_NET);
+
+    let ctl_rx_buf = singleton!(: [u8; DMA_BUF_SIZE] = [0; DMA_BUF_SIZE]).unwrap();
+    let ui_rx_buf = singleton!(: [u8; DMA_BUF_SIZE] = [0; DMA_BUF_SIZE]).unwrap();
+    let net_rx_buf = singleton!(: [u8; DMA_BUF_SIZE] = [0; DMA_BUF_SIZE]).unwrap();
+
+    let (to_ctl, from_ctl) = Uart::new(
+        p.USART1, p.PA10, p.PA9, Irqs, p.DMA1_CH2, p.DMA1_CH3, ctl_config,
+    )
+    .unwrap()
+    .split();
+    let to_ctl = UartTxWrapper(to_ctl);
+    let from_ctl = UartRxWrapper(from_ctl.into_ring_buffered(ctl_rx_buf));
+
+    let (to_ui, from_ui) = Uart::new(
+        p.USART2, p.PA3, p.PA2, Irqs, p.DMA1_CH4, p.DMA1_CH5, ui_config,
+    )
+    .unwrap()
+    .split();
+    let to_ui = UartTxWrapper(to_ui);
+    let from_ui = UartRxWrapper(from_ui.into_ring_buffered(ui_rx_buf));
+
+    let (to_net, from_net) = Uart::new(
+        p.USART3, p.PB11, p.PB10, Irqs, p.DMA1_CH7, p.DMA1_CH6, net_config,
+    )
+    .unwrap()
+    .split();
+    let to_net = UartTxWrapper(to_net);
+    let from_net = UartRxWrapper(from_net.into_ring_buffered(net_rx_buf));
+
+    // EV17 LED A: R=PB5, G=PB4, B=PB1
+    let led_a = (
+        Output::new(p.PB5, Level::Low, Speed::Low),
+        Output::new(p.PB4, Level::Low, Speed::Low),
+        Output::new(p.PB1, Level::Low, Speed::Low),
+    );
+
+    // EV17 board updates:
+    // - PB0 is BATTERY_MON (ADC input)
+    // - PC14 is MGMT_DEBUG1 (output)
+    // - PB15 is NC (floating)
+    // let _battery_mon = Input::new(p.PB0, Pull::None);
+    // let _mgmt_debug1 = Output::new(p.PC14, Level::Low, Speed::Low);
+    // let _pb15_nc = Input::new(p.PB15, Pull::None);
+
+    // LED B no longer exists on EV17.
+    let led_b = (NoopOutputPin, NoopOutputPin, NoopOutputPin);
+
+    let ui_boot0 = Output::new(p.PA15, Level::Low, Speed::Low);
+    let ui_boot1 = Output::new(p.PB8, Level::High, Speed::Low);
+    let ui_rst = Output::new(p.PB3, Level::Low, Speed::Low);
+    let ui_reset_pins = link::mgmt::UiResetPins::new(ui_boot0, ui_boot1, ui_rst);
+
+    let net_boot = Output::new(p.PB6, Level::High, Speed::Low);
+    let net_rst = Output::new(p.PC13, Level::Low, Speed::Low);
+    let net_reset_pins = link::mgmt::NetResetPins::new(net_boot, net_rst);
+
+    link::mgmt::run(
+        to_ctl,
+        from_ctl,
+        to_ui,
+        from_ui,
+        to_net,
+        from_net,
+        led_a,
+        led_b,
+        ui_reset_pins,
+        net_reset_pins,
+        Delay,
+        Stm32Board,
+    )
+    .await;
+}
+
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {
     // Clock configuration matching the C firmware:
@@ -142,91 +331,6 @@ async fn main(_spawner: Spawner) {
     };
     let p = embassy_stm32::init(rcc_config);
 
-    // MCO on PA8: Output 6 MHz clock for UI chip
-    let _mco = Mco::new(p.MCO, p.PA8, McoSource::PLL, McoPrescaler::DIV4);
-
-    // UART configs from centralized definitions
-    // CTL UART always boots at fixed high speed (1000000)
-    let ctl_config = uart_config_to_stm32(link::uart_config::CTL_MGMT);
-
-    // UI UART at high speed (1000000)
-    let ui_config = uart_config_to_stm32(link::uart_config::MGMT_UI);
-
-    let net_config = uart_config_to_stm32(link::uart_config::MGMT_NET);
-
-    // DMA buffers for ring-buffered RX
-    let ctl_rx_buf = singleton!(: [u8; DMA_BUF_SIZE] = [0; DMA_BUF_SIZE]).unwrap();
-    let ui_rx_buf = singleton!(: [u8; DMA_BUF_SIZE] = [0; DMA_BUF_SIZE]).unwrap();
-    let net_rx_buf = singleton!(: [u8; DMA_BUF_SIZE] = [0; DMA_BUF_SIZE]).unwrap();
-
-    // UART to CTL (uses even parity for bootloader compatibility)
-    let (to_ctl, from_ctl) = Uart::new(
-        p.USART1, p.PA10, p.PA9, Irqs, p.DMA1_CH2, p.DMA1_CH3, ctl_config,
-    )
-    .unwrap()
-    .split();
-    let to_ctl = UartTxWrapper(to_ctl);
-    let from_ctl = UartRxWrapper(from_ctl.into_ring_buffered(ctl_rx_buf));
-
-    // UART to UI (uses even parity for bootloader compatibility)
-    let (to_ui, from_ui) = Uart::new(
-        p.USART2, p.PA3, p.PA2, Irqs, p.DMA1_CH4, p.DMA1_CH5, ui_config,
-    )
-    .unwrap()
-    .split();
-    let to_ui = UartTxWrapper(to_ui);
-    let from_ui = UartRxWrapper(from_ui.into_ring_buffered(ui_rx_buf));
-
-    // UART to NET (no parity)
-    let (to_net, from_net) = Uart::new(
-        p.USART3, p.PB11, p.PB10, Irqs, p.DMA1_CH7, p.DMA1_CH6, net_config,
-    )
-    .unwrap()
-    .split();
-    let to_net = UartTxWrapper(to_net);
-    let from_net = UartRxWrapper(from_net.into_ring_buffered(net_rx_buf));
-
-    // RGB LEDs (R, G, B pin tuples)
-    // LED A: R=PA4 (inverted), G=PA6, B=PA7
-    let led_a = (
-        link::InvertedPin(Output::new(p.PA4, Level::Low, Speed::Low)),
-        Output::new(p.PA6, Level::Low, Speed::Low),
-        Output::new(p.PA7, Level::Low, Speed::Low),
-    );
-
-    // LED B: R=PB0, G=PB6, B=PB15
-    let led_b = (
-        Output::new(p.PB0, Level::Low, Speed::Low),
-        Output::new(p.PB6, Level::Low, Speed::Low),
-        Output::new(p.PB15, Level::Low, Speed::Low),
-    );
-
-    // UI chip reset control pins
-    // RST starts low to hold UI in reset until MGMT clocks are stable
-    let ui_boot0 = Output::new(p.PA15, Level::Low, Speed::Low);
-    let ui_boot1 = Output::new(p.PB8, Level::High, Speed::Low);
-    let ui_rst = Output::new(p.PB3, Level::Low, Speed::Low);
-    let ui_reset_pins = link::mgmt::UiResetPins::new(ui_boot0, ui_boot1, ui_rst);
-
-    // NET chip reset control pins
-    // RST starts low to hold NET in reset until MGMT clocks are stable
-    let net_boot = Output::new(p.PB5, Level::High, Speed::Low);
-    let net_rst = Output::new(p.PB4, Level::Low, Speed::Low);
-    let net_reset_pins = link::mgmt::NetResetPins::new(net_boot, net_rst);
-
-    link::mgmt::run(
-        to_ctl,
-        from_ctl,
-        to_ui,
-        from_ui,
-        to_net,
-        from_net,
-        led_a,
-        led_b,
-        ui_reset_pins,
-        net_reset_pins,
-        Delay,
-        CortexMStackMonitor,
-    )
-    .await;
+    ev17_pin_assignments_init(p).await
 }
+

--- a/mgmt/src/main.rs
+++ b/mgmt/src/main.rs
@@ -15,7 +15,7 @@ use embassy_stm32::{
 };
 use embassy_time::Delay;
 use embedded_io_async::{ErrorType, Read, Write};
-use link::uart_config::SetBaudRate;
+use link::{uart_config::SetBaudRate, StackMonitor, mgmt::Board};
 use {defmt_rtt as _, panic_probe as _};
 
 #[derive(Copy, Clone)]
@@ -48,7 +48,7 @@ impl embedded_hal::digital::StatefulOutputPin for NoopOutputPin {
 /// Board implementation for MGMT STM32.
 struct Stm32Board;
 
-impl link::StackMonitor for Stm32Board {
+impl StackMonitor for Stm32Board {
     fn stack(&self) -> core::ops::Range<*mut u32> {
         cortex_m_stack::stack()
     }
@@ -66,7 +66,7 @@ impl link::StackMonitor for Stm32Board {
     }
 }
 
-impl link::mgmt::Board for Stm32Board {
+impl Board for Stm32Board {
     fn board_version(&self) -> u8 {
         embassy_stm32::pac::FLASH.obr().read().data0()
     }
@@ -141,7 +141,7 @@ bind_interrupts!(struct Irqs {
 });
 
 #[allow(dead_code)]
-async fn ev16_pin_assignments_init(p: embassy_stm32::Peripherals) -> ! {
+async fn run_ev16(p: embassy_stm32::Peripherals) -> ! {
     // MCO on PA8: Output 6 MHz clock for UI chip
     let _mco = Mco::new(p.MCO, p.PA8, McoSource::PLL, McoPrescaler::DIV4);
 
@@ -216,7 +216,7 @@ async fn ev16_pin_assignments_init(p: embassy_stm32::Peripherals) -> ! {
     )
     .await;
 }
-async fn ev17_pin_assignments_init(p: embassy_stm32::Peripherals) -> ! {
+async fn run_ev17(p: embassy_stm32::Peripherals) -> ! {
     // MCO on PA8: Output 6 MHz clock for UI chip
     let _mco = Mco::new(p.MCO, p.PA8, McoSource::PLL, McoPrescaler::DIV4);
 
@@ -331,6 +331,11 @@ async fn main(_spawner: Spawner) {
     };
     let p = embassy_stm32::init(rcc_config);
 
-    ev17_pin_assignments_init(p).await
+    match Stm32Board.board_version() {
+        16 => run_ev16(p).await,
+        17 => run_ev17(p).await,
+        _ => loop {}
+        // _ => run_ev17(p).await,
+    }
 }
 

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -22,10 +22,10 @@ use embedded_hal::i2c::I2c as I2cTrait;
 use link::ui::{AudioError, AudioSystem, StereoFrame, STEREO_FRAME_SIZE};
 use {defmt_rtt as _, panic_probe as _};
 
-/// Stack monitor implementation using cortex-m-stack.
-struct CortexMStackMonitor;
+/// Board implementation for UI STM32.
+struct Stm32Board;
 
-impl link::StackMonitor for CortexMStackMonitor {
+impl link::StackMonitor for Stm32Board {
     fn stack(&self) -> core::ops::Range<*mut u32> {
         cortex_m_stack::stack()
     }
@@ -42,6 +42,8 @@ impl link::StackMonitor for CortexMStackMonitor {
         cortex_m_stack::repaint_stack();
     }
 }
+
+impl link::ui::Board for Stm32Board {}
 
 /// Convert centralized UART config to STM32 HAL config.
 fn uart_config_to_stm32(cfg: link::uart_config::Config) -> Config {
@@ -269,7 +271,7 @@ async fn main(_spawner: Spawner) {
         i2c,
         delay,
         audio_system,
-        CortexMStackMonitor,
+        Stm32Board,
     )
     .await;
 }

--- a/web-ctl/src/lib.rs
+++ b/web-ctl/src/lib.rs
@@ -490,6 +490,72 @@ impl LinkController {
         core.mgmt_ping(&data).await.map_err(ctl_error_to_js)
     }
 
+    /// Get the board version reported by the running MGMT firmware.
+    #[wasm_bindgen]
+    pub async fn get_mgmt_board(&mut self) -> Result<u8, JsValue> {
+        let core = self.core_mut()?;
+        core.mgmt_get_board_version().await.map_err(ctl_error_to_js)
+    }
+
+    /// Get the MGMT DATA0 option-byte version via the STM32 bootloader.
+    #[wasm_bindgen]
+    pub async fn get_mgmt_version(&mut self) -> Result<u8, JsValue> {
+        let core = self.core_mut()?;
+
+        let _ = core
+            .port_mut()
+            .set_timeout(std::time::Duration::from_millis(
+                timeouts::BOOTLOADER_PROBE_MS,
+            ));
+        let entry = core
+            .try_enter_mgmt_bootloader(|ms| js_sleep(ms as u32))
+            .await;
+        let _ = core
+            .port_mut()
+            .set_timeout(std::time::Duration::from_secs(timeouts::NORMAL_SECS));
+
+        let skip_init = match entry {
+            MgmtBootloaderEntry::AutoReset | MgmtBootloaderEntry::AlreadyActive => true,
+            MgmtBootloaderEntry::NotDetected => false,
+        };
+
+        let value = core
+            .get_mgmt_data0_option_byte(skip_init)
+            .await
+            .map_err(|e| JsValue::from_str(&format!("Bootloader error: {:?}", e)))?;
+        core.exit_mgmt_bootloader(|ms| js_sleep(ms as u32)).await;
+        Ok(value)
+    }
+
+    /// Set the MGMT DATA0 option-byte version via the STM32 bootloader.
+    #[wasm_bindgen]
+    pub async fn set_mgmt_version(&mut self, version: u8) -> Result<(), JsValue> {
+        let core = self.core_mut()?;
+
+        let _ = core
+            .port_mut()
+            .set_timeout(std::time::Duration::from_millis(
+                timeouts::BOOTLOADER_PROBE_MS,
+            ));
+        let entry = core
+            .try_enter_mgmt_bootloader(|ms| js_sleep(ms as u32))
+            .await;
+        let _ = core
+            .port_mut()
+            .set_timeout(std::time::Duration::from_secs(timeouts::NORMAL_SECS));
+
+        let skip_init = match entry {
+            MgmtBootloaderEntry::AutoReset | MgmtBootloaderEntry::AlreadyActive => true,
+            MgmtBootloaderEntry::NotDetected => false,
+        };
+
+        core.set_mgmt_data0_option_byte(skip_init, version)
+            .await
+            .map_err(|e| JsValue::from_str(&format!("Bootloader error: {:?}", e)))?;
+        core.exit_mgmt_bootloader(|ms| js_sleep(ms as u32)).await;
+        Ok(())
+    }
+
     /// Ping the UI chip.
     #[wasm_bindgen]
     pub async fn ping_ui(&mut self, data: Vec<u8>) -> Result<(), JsValue> {

--- a/web-ctl/www/index.html
+++ b/web-ctl/www/index.html
@@ -963,6 +963,25 @@
                 </div>
 
                 <div class="card-section">
+                    <h3>Board and Version</h3>
+                    <div class="form-group">
+                        <label>Board Version (running MGMT firmware)</label>
+                        <div class="inline-form">
+                            <input type="text" id="mgmtBoardInput" placeholder="(click Read Board)" class="mono" readonly>
+                            <button class="btn-secondary" id="getMgmtBoardBtn">Read Board</button>
+                        </div>
+                    </div>
+                    <div class="form-group">
+                        <label>Version Option Byte (DATA0)</label>
+                        <div class="inline-form">
+                            <input type="number" id="mgmtVersionInput" placeholder="0-255" class="mono" min="0" max="255">
+                            <button class="btn-secondary" id="getMgmtVersionBtn">Read Version</button>
+                            <button class="btn-primary" id="setMgmtVersionBtn">Write Version</button>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="card-section">
                     <h3>Stack Diagnostics</h3>
                     <div class="btn-group" style="margin-bottom: 0.75rem;">
                         <button class="btn-secondary" id="getMgmtStackBtn">Get Stack Info</button>
@@ -1681,6 +1700,41 @@
                 log('MGMT ping successful - received pong', 'success');
             } catch (e) {
                 log(`MGMT ping error: ${e}`, 'error');
+            }
+        });
+
+        document.getElementById('getMgmtBoardBtn').addEventListener('click', async () => {
+            try {
+                const version = await controller.get_mgmt_board();
+                document.getElementById('mgmtBoardInput').value = version.toString();
+                log(`MGMT board version: ${version}`, 'success');
+            } catch (e) {
+                log(`Read MGMT board version error: ${e}`, 'error');
+            }
+        });
+
+        document.getElementById('getMgmtVersionBtn').addEventListener('click', async () => {
+            try {
+                const version = await controller.get_mgmt_version();
+                document.getElementById('mgmtVersionInput').value = version.toString();
+                log(`MGMT DATA0 version: ${version}`, 'success');
+            } catch (e) {
+                log(`Read MGMT version error: ${e}`, 'error');
+            }
+        });
+
+        document.getElementById('setMgmtVersionBtn').addEventListener('click', async () => {
+            try {
+                const input = document.getElementById('mgmtVersionInput').value;
+                const version = parseInt(input, 10);
+                if (!Number.isInteger(version) || version < 0 || version > 255) {
+                    log('MGMT version must be an integer from 0 to 255', 'error');
+                    return;
+                }
+                await controller.set_mgmt_version(version);
+                log(`MGMT DATA0 version set to ${version}`, 'success');
+            } catch (e) {
+                log(`Write MGMT version error: ${e}`, 'error');
             }
         });
 


### PR DESCRIPTION
## Summary
- Add `mgmt version [get|set <u8>]` to CTL so the MGMT DATA0 option byte can be read or updated from the CLI and REPL
- Fix MGMT option-byte writes to program the full 16-byte option-byte block from the base address and verify the result with a fresh bootloader session
- Add `mgmt board` to CTL and MGMT firmware so the running MGMT firmware can report the board version from the DATA0 option byte
- Add `web-ctl` UI and bindings for reading the MGMT board version and reading or writing the MGMT DATA0 option-byte version
- Refactor Board traits into module-specific types (`link::mgmt::Board`, `link::ui::Board`) extending common `StackMonitor`
- MGMT firmware now dispatches to EV16 or EV17 pin assignments based on board version option byte
- Refactor MGMT main to extract common peripheral setup into `setup_common()` function
- Fix stale response bug in `wait_for_mgmt_ready` by using unique challenges per attempt and draining buffer first
- Fix 30-second delay after MGMT flash by removing redundant wait at wrong baud rate

## Testing
- `cargo build` in `mgmt`
- `cargo build` in `ctl`
- `cargo build` in `web-ctl`
- `cargo test --features std` in `link`

🤖 Generated with [Claude Code](https://claude.ai/code)