### PR TITLE
Add UI volume control commands

### DIFF
--- a/ctl/src/handlers/ui.rs
+++ b/ctl/src/handlers/ui.rs
@@ -2,7 +2,7 @@
 
 use super::Core;
 use crate::{
-    GetSetHex, GetSetU16, GetSetU32, LogsAction, LoopbackAction, PinAction, PinLevel, ResetAction,
+    GetSetHex, GetSetU8, GetSetU32, LogsAction, LoopbackAction, PinAction, PinLevel, ResetAction,
     StackAction, UiAction,
 };
 use indicatif::{ProgressBar, ProgressStyle};
@@ -374,12 +374,12 @@ pub async fn handle_ui(
             Ok(())
         }
         UiAction::Volume { action } => match action.unwrap_or_default() {
-            GetSetU16::Get => {
+            GetSetU8::Get => {
                 let volume = core.ui_get_volume().await?;
                 println!("{}", volume);
                 Ok(())
             }
-            GetSetU16::Set { value } => {
+            GetSetU8::Set { value } => {
                 core.ui_set_volume(value).await?;
                 println!("Volume set to {}", value);
                 Ok(())

--- a/ctl/src/handlers/ui.rs
+++ b/ctl/src/handlers/ui.rs
@@ -2,7 +2,7 @@
 
 use super::Core;
 use crate::{
-    GetSetHex, GetSetU32, LogsAction, LoopbackAction, PinAction, PinLevel, ResetAction,
+    GetSetHex, GetSetU16, GetSetU32, LogsAction, LoopbackAction, PinAction, PinLevel, ResetAction,
     StackAction, UiAction,
 };
 use indicatif::{ProgressBar, ProgressStyle};
@@ -373,5 +373,17 @@ pub async fn handle_ui(
             println!("UI storage cleared");
             Ok(())
         }
+        UiAction::Volume { action } => match action.unwrap_or_default() {
+            GetSetU16::Get => {
+                let volume = core.ui_get_volume().await?;
+                println!("{}", volume);
+                Ok(())
+            }
+            GetSetU16::Set { value } => {
+                core.ui_set_volume(value).await?;
+                println!("Volume set to {}", value);
+                Ok(())
+            }
+        },
     }
 }

--- a/ctl/src/main.rs
+++ b/ctl/src/main.rs
@@ -150,7 +150,7 @@ enum UiAction {
     /// Get or set the UI output volume
     Volume {
         #[command(subcommand)]
-        action: Option<GetSetU16>,
+        action: Option<GetSetU8>,
     },
 
     /// Set UI BOOT0 pin
@@ -265,15 +265,6 @@ enum GetSetU8 {
     Get,
     /// Set a new value
     Set { value: u8 },
-}
-
-#[derive(Debug, Clone, Default, Subcommand)]
-enum GetSetU16 {
-    /// Get the current value
-    #[default]
-    Get,
-    /// Set a new value
-    Set { value: u16 },
 }
 
 #[derive(Debug, Clone, Default, Subcommand)]

--- a/ctl/src/main.rs
+++ b/ctl/src/main.rs
@@ -147,6 +147,12 @@ enum UiAction {
         action: Option<LoopbackAction>,
     },
 
+    /// Get or set the UI output volume
+    Volume {
+        #[command(subcommand)]
+        action: Option<GetSetU16>,
+    },
+
     /// Set UI BOOT0 pin
     Boot0 {
         #[command(subcommand)]
@@ -259,6 +265,15 @@ enum GetSetU8 {
     Get,
     /// Set a new value
     Set { value: u8 },
+}
+
+#[derive(Debug, Clone, Default, Subcommand)]
+enum GetSetU16 {
+    /// Get the current value
+    #[default]
+    Get,
+    /// Set a new value
+    Set { value: u16 },
 }
 
 #[derive(Debug, Clone, Default, Subcommand)]

--- a/link/src/ctl/core.rs
+++ b/link/src/ctl/core.rs
@@ -883,6 +883,40 @@ impl<P: CtlPort> CtlCore<P> {
         Ok(())
     }
 
+    /// Get UI chip output volume.
+    pub async fn ui_get_volume(&mut self) -> Result<u16, CtlError> {
+        self.write_tlv_ui(CtlToUi::GetVolume, &[]).await?;
+        let tlv = self.read_tlv_ui_skip_log().await?;
+        if tlv.tlv_type != UiToCtl::Volume {
+            return Err(CtlError::UnexpectedResponse {
+                expected: "Volume",
+                actual: format!("{:?}", tlv.tlv_type),
+            });
+        }
+        if tlv.value.len() != 2 {
+            return Err(CtlError::InvalidLength {
+                expected: 2,
+                actual: tlv.value.len(),
+            });
+        }
+        let volume = u16::from_le_bytes([tlv.value[0], tlv.value[1]]);
+        Ok(volume)
+    }
+
+    /// Set UI chip output volume.
+    pub async fn ui_set_volume(&mut self, volume: u16) -> Result<(), CtlError> {
+        self.write_tlv_ui(CtlToUi::SetVolume, &volume.to_le_bytes())
+            .await?;
+        let tlv = self.read_tlv_ui_skip_log().await?;
+        if tlv.tlv_type != UiToCtl::Ack {
+            return Err(CtlError::UnexpectedResponse {
+                expected: "Ack",
+                actual: format!("{:?}", tlv.tlv_type),
+            });
+        }
+        Ok(())
+    }
+
     /// Set UI chip BOOT0 pin directly.
     pub async fn set_ui_boot0(&mut self, value: crate::shared::PinValue) -> Result<(), CtlError> {
         use crate::shared::Pin;

--- a/link/src/ctl/core.rs
+++ b/link/src/ctl/core.rs
@@ -884,7 +884,7 @@ impl<P: CtlPort> CtlCore<P> {
     }
 
     /// Get UI chip output volume.
-    pub async fn ui_get_volume(&mut self) -> Result<u16, CtlError> {
+    pub async fn ui_get_volume(&mut self) -> Result<u8, CtlError> {
         self.write_tlv_ui(CtlToUi::GetVolume, &[]).await?;
         let tlv = self.read_tlv_ui_skip_log().await?;
         if tlv.tlv_type != UiToCtl::Volume {
@@ -893,20 +893,18 @@ impl<P: CtlPort> CtlCore<P> {
                 actual: format!("{:?}", tlv.tlv_type),
             });
         }
-        if tlv.value.len() != 2 {
+        if tlv.value.len() != 1 {
             return Err(CtlError::InvalidLength {
-                expected: 2,
+                expected: 1,
                 actual: tlv.value.len(),
             });
         }
-        let volume = u16::from_le_bytes([tlv.value[0], tlv.value[1]]);
-        Ok(volume)
+        Ok(tlv.value[0])
     }
 
     /// Set UI chip output volume.
-    pub async fn ui_set_volume(&mut self, volume: u16) -> Result<(), CtlError> {
-        self.write_tlv_ui(CtlToUi::SetVolume, &volume.to_le_bytes())
-            .await?;
+    pub async fn ui_set_volume(&mut self, volume: u8) -> Result<(), CtlError> {
+        self.write_tlv_ui(CtlToUi::SetVolume, &[volume]).await?;
         let tlv = self.read_tlv_ui_skip_log().await?;
         if tlv.tlv_type != UiToCtl::Ack {
             return Err(CtlError::UnexpectedResponse {

--- a/link/src/shared/protocol.rs
+++ b/link/src/shared/protocol.rs
@@ -183,9 +183,9 @@ pub enum CtlToUi {
     SetLogsEnabled,
     /// Clear all stored configuration (EEPROM)
     ClearStorage,
-    /// Get output volume (returns 2 bytes: u16 little-endian)
+    /// Get output volume (returns 1 byte: u8)
     GetVolume,
-    /// Set output volume (2 bytes: u16 little-endian)
+    /// Set output volume (1 byte: u8)
     SetVolume,
 }
 
@@ -206,7 +206,7 @@ pub enum UiToCtl {
     StackInfo,
     /// Logs enabled state (1 byte: 0=disabled, 1=enabled)
     LogsEnabled,
-    /// Output volume (2 bytes: u16 little-endian)
+    /// Output volume (1 byte: u8)
     Volume,
 }
 

--- a/link/src/shared/protocol.rs
+++ b/link/src/shared/protocol.rs
@@ -183,6 +183,10 @@ pub enum CtlToUi {
     SetLogsEnabled,
     /// Clear all stored configuration (EEPROM)
     ClearStorage,
+    /// Get output volume (returns 2 bytes: u16 little-endian)
+    GetVolume,
+    /// Set output volume (2 bytes: u16 little-endian)
+    SetVolume,
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, IntoPrimitive, TryFromPrimitive)]
@@ -202,6 +206,8 @@ pub enum UiToCtl {
     StackInfo,
     /// Logs enabled state (1 byte: 0=disabled, 1=enabled)
     LogsEnabled,
+    /// Output volume (2 bytes: u16 little-endian)
+    Volume,
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, IntoPrimitive, TryFromPrimitive)]

--- a/link/src/ui/eeprom.rs
+++ b/link/src/ui/eeprom.rs
@@ -20,7 +20,6 @@ where
     const I2C_ADDR: u8 = 0x50;
     const VERSION_OFFSET: u8 = 0;
     const SFRAME_KEY_OFFSET: u8 = 16;
-    const VOLUME_OFFSET: u8 = 32;
     const WRITE_DELAY_NS: u32 = 10_000_000;
 
     /// Create a new EEPROM interface from shared I2C and delay references.
@@ -59,24 +58,6 @@ where
         let mut write_data = [0u8; 17];
         write_data[0] = Self::SFRAME_KEY_OFFSET;
         write_data[1..].copy_from_slice(key);
-        self.i2c.write(Self::I2C_ADDR, &write_data)?;
-        self.delay.delay_ns(Self::WRITE_DELAY_NS);
-        Ok(())
-    }
-
-    /// Read the volume field (2 bytes little-endian u16 at offset 32).
-    pub fn get_volume(&mut self) -> Result<u16, I::Error> {
-        let mut buf = [0u8; 2];
-        self.i2c
-            .write_read(Self::I2C_ADDR, &[Self::VOLUME_OFFSET], &mut buf)?;
-        Ok(u16::from_le_bytes(buf))
-    }
-
-    /// Write the volume field (2 bytes little-endian u16 at offset 32).
-    pub fn set_volume(&mut self, volume: u16) -> Result<(), I::Error> {
-        let mut write_data = [0u8; 3];
-        write_data[0] = Self::VOLUME_OFFSET;
-        write_data[1..].copy_from_slice(&volume.to_le_bytes());
         self.i2c.write(Self::I2C_ADDR, &write_data)?;
         self.delay.delay_ns(Self::WRITE_DELAY_NS);
         Ok(())

--- a/link/src/ui/eeprom.rs
+++ b/link/src/ui/eeprom.rs
@@ -20,6 +20,7 @@ where
     const I2C_ADDR: u8 = 0x50;
     const VERSION_OFFSET: u8 = 0;
     const SFRAME_KEY_OFFSET: u8 = 16;
+    const VOLUME_OFFSET: u8 = 32;
     const WRITE_DELAY_NS: u32 = 10_000_000;
 
     /// Create a new EEPROM interface from shared I2C and delay references.
@@ -58,6 +59,24 @@ where
         let mut write_data = [0u8; 17];
         write_data[0] = Self::SFRAME_KEY_OFFSET;
         write_data[1..].copy_from_slice(key);
+        self.i2c.write(Self::I2C_ADDR, &write_data)?;
+        self.delay.delay_ns(Self::WRITE_DELAY_NS);
+        Ok(())
+    }
+
+    /// Read the volume field (2 bytes little-endian u16 at offset 32).
+    pub fn get_volume(&mut self) -> Result<u16, I::Error> {
+        let mut buf = [0u8; 2];
+        self.i2c
+            .write_read(Self::I2C_ADDR, &[Self::VOLUME_OFFSET], &mut buf)?;
+        Ok(u16::from_le_bytes(buf))
+    }
+
+    /// Write the volume field (2 bytes little-endian u16 at offset 32).
+    pub fn set_volume(&mut self, volume: u16) -> Result<(), I::Error> {
+        let mut write_data = [0u8; 3];
+        write_data[0] = Self::VOLUME_OFFSET;
+        write_data[1..].copy_from_slice(&volume.to_le_bytes());
         self.i2c.write(Self::I2C_ADDR, &write_data)?;
         self.delay.delay_ns(Self::WRITE_DELAY_NS);
         Ok(())

--- a/link/src/ui/mod.rs
+++ b/link/src/ui/mod.rs
@@ -111,6 +111,9 @@ where
     // Shared logs enabled state
     let logs_enabled = AtomicBool::new(true);
 
+    // Shared volume level (TODO: actually configure the audio system)
+    let volume = AtomicU8::new(255);
+
     // Shared button state - true when any button is pressed
     // This allows audio_task to skip sending frames when no button is held
     let button_active = AtomicBool::new(false);
@@ -139,6 +142,7 @@ where
                         &mut delay,
                         &loopback_mode,
                         &logs_enabled,
+                        &volume,
                         &mut sframe_state,
                         &board,
                     )
@@ -386,6 +390,7 @@ async fn handle_mgmt<M, N, I, D, B>(
     delay: &mut D,
     loopback_mode: &AtomicU8,
     logs_enabled: &AtomicBool,
+    volume: &AtomicU8,
     sframe_state: &mut sframe::SFrameState,
     board: &B,
 ) where
@@ -525,28 +530,13 @@ async fn handle_mgmt<M, N, I, D, B>(
         }
         CtlToUi::GetVolume => {
             info!("ui: get volume");
-            let mut eeprom = Eeprom::new(i2c, delay);
-            let Ok(volume) = eeprom.get_volume() else {
-                info!("ui: failed to read volume from EEPROM");
-                return;
-            };
-            let value = volume.to_le_bytes();
-            to_mgmt.must_write_tlv(UiToCtl::Volume, &value).await;
+            let vol = volume.load(Ordering::Relaxed);
+            to_mgmt.must_write_tlv(UiToCtl::Volume, &[vol]).await;
         }
         CtlToUi::SetVolume => {
-            info!("ui: set volume");
-            if tlv.value.len() != 2 {
-                info!("ui: invalid volume length: {}", tlv.value.len());
-                to_mgmt.must_write_tlv(UiToCtl::Error, b"length").await;
-                return;
-            }
-            let volume = u16::from_le_bytes([tlv.value[0], tlv.value[1]]);
-            let mut eeprom = Eeprom::new(i2c, delay);
-            if eeprom.set_volume(volume).is_err() {
-                info!("ui: failed to write volume to EEPROM");
-                to_mgmt.must_write_tlv(UiToCtl::Error, b"eeprom").await;
-                return;
-            }
+            let vol = tlv.value.first().copied().unwrap_or(255);
+            info!("ui: set volume = {}", vol);
+            volume.store(vol, Ordering::Relaxed);
             to_mgmt.must_write_tlv(UiToCtl::Ack, &[]).await;
         }
     }
@@ -635,6 +625,7 @@ mod tests {
 
         let loopback_mode = AtomicU8::new(UiLoopbackMode::Off as u8);
         let logs_enabled = AtomicBool::new(true);
+        let volume = AtomicU8::new(255);
         let mut sframe_state = sframe::SFrameState::new(&[0u8; 16], 0);
         handle_mgmt(
             tlv,
@@ -644,6 +635,7 @@ mod tests {
             &mut delay,
             &loopback_mode,
             &logs_enabled,
+            &volume,
             &mut sframe_state,
             &crate::shared::NoOpBoard,
         )
@@ -672,6 +664,7 @@ mod tests {
 
         let loopback_mode = AtomicU8::new(UiLoopbackMode::Off as u8);
         let logs_enabled = AtomicBool::new(true);
+        let volume = AtomicU8::new(255);
         let mut sframe_state = sframe::SFrameState::new(&[0u8; 16], 0);
         handle_mgmt(
             tlv,
@@ -681,6 +674,7 @@ mod tests {
             &mut delay,
             &loopback_mode,
             &logs_enabled,
+            &volume,
             &mut sframe_state,
             &crate::shared::NoOpBoard,
         )
@@ -715,6 +709,7 @@ mod tests {
 
         let loopback_mode = AtomicU8::new(UiLoopbackMode::Off as u8);
         let logs_enabled = AtomicBool::new(true);
+        let volume = AtomicU8::new(255);
         let mut sframe_state = sframe::SFrameState::new(&[0u8; 16], 0);
         handle_mgmt(
             tlv,
@@ -724,6 +719,7 @@ mod tests {
             &mut delay,
             &loopback_mode,
             &logs_enabled,
+            &volume,
             &mut sframe_state,
             &crate::shared::NoOpBoard,
         )
@@ -755,6 +751,7 @@ mod tests {
 
         let loopback_mode = AtomicU8::new(UiLoopbackMode::Off as u8);
         let logs_enabled = AtomicBool::new(true);
+        let volume = AtomicU8::new(255);
         let mut sframe_state = sframe::SFrameState::new(&[0u8; 16], 0);
         handle_mgmt(
             tlv,
@@ -764,6 +761,7 @@ mod tests {
             &mut delay,
             &loopback_mode,
             &logs_enabled,
+            &volume,
             &mut sframe_state,
             &crate::shared::NoOpBoard,
         )
@@ -793,6 +791,7 @@ mod tests {
 
         let loopback_mode = AtomicU8::new(UiLoopbackMode::Off as u8);
         let logs_enabled = AtomicBool::new(true);
+        let volume = AtomicU8::new(255);
         let mut sframe_state = sframe::SFrameState::new(&[0u8; 16], 0);
         handle_mgmt(
             tlv,
@@ -802,6 +801,7 @@ mod tests {
             &mut delay,
             &loopback_mode,
             &logs_enabled,
+            &volume,
             &mut sframe_state,
             &crate::shared::NoOpBoard,
         )
@@ -831,6 +831,7 @@ mod tests {
 
         let loopback_mode = AtomicU8::new(UiLoopbackMode::Off as u8);
         let logs_enabled = AtomicBool::new(true);
+        let volume = AtomicU8::new(255);
         let mut sframe_state = sframe::SFrameState::new(&[0u8; 16], 0);
         handle_mgmt(
             tlv,
@@ -840,6 +841,7 @@ mod tests {
             &mut delay,
             &loopback_mode,
             &logs_enabled,
+            &volume,
             &mut sframe_state,
             &crate::shared::NoOpBoard,
         )

--- a/link/src/ui/mod.rs
+++ b/link/src/ui/mod.rs
@@ -523,6 +523,32 @@ async fn handle_mgmt<M, N, I, D, B>(
             sframe_state.reset(&[0x00; 16], 0);
             to_mgmt.must_write_tlv(UiToCtl::Ack, &[]).await;
         }
+        CtlToUi::GetVolume => {
+            info!("ui: get volume");
+            let mut eeprom = Eeprom::new(i2c, delay);
+            let Ok(volume) = eeprom.get_volume() else {
+                info!("ui: failed to read volume from EEPROM");
+                return;
+            };
+            let value = volume.to_le_bytes();
+            to_mgmt.must_write_tlv(UiToCtl::Volume, &value).await;
+        }
+        CtlToUi::SetVolume => {
+            info!("ui: set volume");
+            if tlv.value.len() != 2 {
+                info!("ui: invalid volume length: {}", tlv.value.len());
+                to_mgmt.must_write_tlv(UiToCtl::Error, b"length").await;
+                return;
+            }
+            let volume = u16::from_le_bytes([tlv.value[0], tlv.value[1]]);
+            let mut eeprom = Eeprom::new(i2c, delay);
+            if eeprom.set_volume(volume).is_err() {
+                info!("ui: failed to write volume to EEPROM");
+                to_mgmt.must_write_tlv(UiToCtl::Error, b"eeprom").await;
+                return;
+            }
+            to_mgmt.must_write_tlv(UiToCtl::Ack, &[]).await;
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Add `ui volume` command to get/set the UI chip output volume (u8, 0-255)
- Volume stored in-memory via AtomicU8 (not persisted)
- Protocol types: `CtlToUi::GetVolume`, `CtlToUi::SetVolume`, `UiToCtl::Volume`
- TODO: actually configure the audio system with the volume value

## Test plan
- [x] Build ctl: `cd ctl && cargo build`
- [x] Run link tests: `cd link && cargo test --features std`
- [x] Test on hardware: `ctl ui volume` (get), `ctl ui volume set 128` (set)

🤖 Generated with [Claude Code](https://claude.com/claude-code)