### PR TITLE
UI mic preamp controls

### DIFF
--- a/ctl/src/handlers/mgmt.rs
+++ b/ctl/src/handlers/mgmt.rs
@@ -110,15 +110,6 @@ pub async fn handle_mgmt(
     action: MgmtAction,
     core: &mut Core,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let needs_mgmt_firmware = matches!(
-        &action,
-        MgmtAction::Ping { .. } | MgmtAction::Board | MgmtAction::Stack { .. }
-    );
-
-    if needs_mgmt_firmware && !core.wait_for_mgmt_ready(50).await {
-        return Err("MGMT chip not responding (timed out)".into());
-    }
-
     match action {
         MgmtAction::Ping { data } => {
             println!("Sending MGMT ping with data: {}", data);

--- a/ctl/src/handlers/ui.rs
+++ b/ctl/src/handlers/ui.rs
@@ -380,8 +380,8 @@ pub async fn handle_ui(
                 Ok(())
             }
             VolumeAction::Set { value } => {
-                core.ui_set_volume(value).await?;
-                println!("Volume set to {}", value);
+                let volume = core.ui_set_volume(value).await?;
+                println!("Volume set to {}", volume);
                 Ok(())
             }
             VolumeAction::Up { amount } => {
@@ -406,8 +406,8 @@ pub async fn handle_ui(
                 Ok(())
             }
             VolumeAction::Set { value } => {
-                core.ui_set_mic_preamp(value).await?;
-                println!("Mic preamp set to {}", value);
+                let preamp = core.ui_set_mic_preamp(value).await?;
+                println!("Mic preamp set to {}", preamp);
                 Ok(())
             }
             VolumeAction::Up { amount } => {

--- a/ctl/src/handlers/ui.rs
+++ b/ctl/src/handlers/ui.rs
@@ -2,14 +2,14 @@
 
 use super::Core;
 use crate::{
-    GetSetHex, GetSetU8, GetSetU32, LogsAction, LoopbackAction, PinAction, PinLevel, ResetAction,
-    StackAction, UiAction,
+    GetSetHex, GetSetU32, LogsAction, LoopbackAction, PinAction, PinLevel, ResetAction,
+    StackAction, UiAction, VolumeAction,
 };
 use indicatif::{ProgressBar, ProgressStyle};
 use link::ctl::SetTimeout;
 use link::ctl::flash::FlashPhase;
 use link::protocol_config::timeouts;
-use link::{PinValue, UiLoopbackMode};
+use link::{AdjDirection, PinValue, UiLoopbackMode};
 use std::io::Write;
 use std::time::Duration;
 
@@ -374,14 +374,54 @@ pub async fn handle_ui(
             Ok(())
         }
         UiAction::Volume { action } => match action.unwrap_or_default() {
-            GetSetU8::Get => {
+            VolumeAction::Get => {
                 let volume = core.ui_get_volume().await?;
                 println!("{}", volume);
                 Ok(())
             }
-            GetSetU8::Set { value } => {
+            VolumeAction::Set { value } => {
                 core.ui_set_volume(value).await?;
                 println!("Volume set to {}", value);
+                Ok(())
+            }
+            VolumeAction::Up { amount } => {
+                let volume = core
+                    .ui_adjust_volume(AdjDirection::Up, amount.unwrap_or(1))
+                    .await?;
+                println!("Volume set to {}", volume);
+                Ok(())
+            }
+            VolumeAction::Down { amount } => {
+                let volume = core
+                    .ui_adjust_volume(AdjDirection::Down, amount.unwrap_or(1))
+                    .await?;
+                println!("Volume set to {}", volume);
+                Ok(())
+            }
+        },
+        UiAction::MicPreamp { action } => match action.unwrap_or_default() {
+            VolumeAction::Get => {
+                let preamp = core.ui_get_mic_preamp().await?;
+                println!("{}", preamp);
+                Ok(())
+            }
+            VolumeAction::Set { value } => {
+                core.ui_set_mic_preamp(value).await?;
+                println!("Mic preamp set to {}", value);
+                Ok(())
+            }
+            VolumeAction::Up { amount } => {
+                let preamp = core
+                    .ui_adjust_mic_preamp(AdjDirection::Up, amount.unwrap_or(1))
+                    .await?;
+                println!("Mic preamp set to {}", preamp);
+                Ok(())
+            }
+            VolumeAction::Down { amount } => {
+                let preamp = core
+                    .ui_adjust_mic_preamp(AdjDirection::Down, amount.unwrap_or(1))
+                    .await?;
+                println!("Mic preamp set to {}", preamp);
                 Ok(())
             }
         },

--- a/ctl/src/main.rs
+++ b/ctl/src/main.rs
@@ -150,7 +150,14 @@ enum UiAction {
     /// Get or set the UI output volume
     Volume {
         #[command(subcommand)]
-        action: Option<GetSetU8>,
+        action: Option<VolumeAction>,
+    },
+
+    /// Get or set the UI microphone preamp
+    #[command(name = "mic-preamp")]
+    MicPreamp {
+        #[command(subcommand)]
+        action: Option<VolumeAction>,
     },
 
     /// Set UI BOOT0 pin
@@ -265,6 +272,19 @@ enum GetSetU8 {
     Get,
     /// Set a new value
     Set { value: u8 },
+}
+
+#[derive(Debug, Clone, Default, Subcommand)]
+enum VolumeAction {
+    /// Get the current value
+    #[default]
+    Get,
+    /// Set a new value
+    Set { value: u8 },
+    /// Increase volume by an optional amount
+    Up { amount: Option<u8> },
+    /// Decrease volume by an optional amount
+    Down { amount: Option<u8> },
 }
 
 #[derive(Debug, Clone, Default, Subcommand)]

--- a/link/src/ctl/core.rs
+++ b/link/src/ctl/core.rs
@@ -12,8 +12,8 @@ use crate::shared::protocol_config::retries::MAX_TLV_SKIP;
 use crate::shared::timing::reset::ESP32_RESET_HOLD_MS;
 use crate::shared::tlv::{buffer, tunnel};
 use crate::shared::{
-    CtlToMgmt, CtlToNet, CtlToUi, HEADER_SIZE, MAX_VALUE_SIZE, MgmtToCtl, NetLoopbackMode,
-    NetToCtl, SYNC_WORD, StackInfo, Tlv, UiLoopbackMode, UiToCtl, WifiSsid,
+    AdjDirection, CtlToMgmt, CtlToNet, CtlToUi, HEADER_SIZE, MgmtToCtl, NetLoopbackMode, NetToCtl,
+    SYNC_WORD, StackInfo, Tlv, UiLoopbackMode, UiToCtl, WifiSsid,
 };
 
 use super::port::CtlPort;
@@ -116,6 +116,7 @@ impl std::error::Error for CtlError {}
 /// chips via the TLV protocol. It works with any type implementing `CtlPort`.
 pub struct CtlCore<P: CtlPort> {
     port: Option<P>,
+    mgmt_buffer: Vec<u8>,
     ui_buffer: Vec<u8>,
     net_buffer: Vec<u8>,
 }
@@ -125,6 +126,7 @@ impl<P: CtlPort> CtlCore<P> {
     pub fn new(port: P) -> Self {
         Self {
             port: Some(port),
+            mgmt_buffer: Vec::new(),
             ui_buffer: Vec::new(),
             net_buffer: Vec::new(),
         }
@@ -183,64 +185,31 @@ impl<P: CtlPort> CtlCore<P> {
     ///
     /// This clears both the internal TLV buffers and the port's read buffer.
     pub fn drain(&mut self) {
+        self.mgmt_buffer.clear();
         self.ui_buffer.clear();
         self.net_buffer.clear();
         self.port_mut().clear_buffer();
     }
 
-    /// Read a TLV from the port, scanning for sync word.
+    /// Read a TLV from the MGMT stream using buffered parsing.
     async fn read_tlv<T: TryFrom<u16>>(&mut self) -> Result<Option<Tlv<T>>, CtlError> {
-        // Scan for sync word byte-by-byte
-        let mut matched = 0usize;
-        let mut buf = [0u8; 1];
-        while matched < SYNC_WORD.len() {
-            let n = match self.port_mut().read(&mut buf).await {
+        loop {
+            if let Some(tlv) = Self::try_parse_tlv_from_buffer::<T>(&mut self.mgmt_buffer)? {
+                return Ok(Some(tlv));
+            }
+
+            let mut chunk = [0u8; 256];
+            let n = match self.port_mut().read(&mut chunk).await {
                 Ok(n) => n,
                 Err(e) if P::is_timeout(&e) => return Ok(None),
                 Err(e) => return Err(CtlError::Port(format!("{:?}", e))),
             };
             if n == 0 {
-                return Ok(None); // EOF
+                return Ok(None);
             }
 
-            if buf[0] == SYNC_WORD[matched] {
-                matched += 1;
-            } else {
-                matched = 0;
-                if buf[0] == SYNC_WORD[0] {
-                    matched = 1;
-                }
-            }
+            let _ = self.mgmt_buffer.extend_from_slice(&chunk[..n]);
         }
-
-        // Read header
-        let mut header = [0u8; HEADER_SIZE];
-        self.port_mut()
-            .read_exact(&mut header)
-            .await
-            .map_err(|e| CtlError::Port(format!("{:?}", e)))?;
-
-        // Decode header
-        let raw_type = u16::from_le_bytes([header[0], header[1]]);
-        let length = u32::from_le_bytes([header[2], header[3], header[4], header[5]]) as usize;
-
-        // Check type first
-        let Ok(tlv_type) = T::try_from(raw_type) else {
-            return Err(CtlError::InvalidType(raw_type));
-        };
-
-        // Read value
-        let mut value = heapless::Vec::<u8, MAX_VALUE_SIZE>::new();
-        if value.resize(length, 0).is_err() {
-            return Err(CtlError::TooLong);
-        }
-
-        self.port_mut()
-            .read_exact(&mut value)
-            .await
-            .map_err(|e| CtlError::Port(format!("{:?}", e)))?;
-
-        Ok(Some(Tlv { tlv_type, value }))
     }
 
     /// Write a TLV to the port with sync word prefix.
@@ -903,16 +872,108 @@ impl<P: CtlPort> CtlCore<P> {
     }
 
     /// Set UI chip output volume.
-    pub async fn ui_set_volume(&mut self, volume: u8) -> Result<(), CtlError> {
+    pub async fn ui_set_volume(&mut self, volume: u8) -> Result<u8, CtlError> {
         self.write_tlv_ui(CtlToUi::SetVolume, &[volume]).await?;
         let tlv = self.read_tlv_ui_skip_log().await?;
-        if tlv.tlv_type != UiToCtl::Ack {
+        if tlv.tlv_type != UiToCtl::Volume {
             return Err(CtlError::UnexpectedResponse {
-                expected: "Ack",
+                expected: "Volume",
                 actual: format!("{:?}", tlv.tlv_type),
             });
         }
-        Ok(())
+        if tlv.value.len() != 1 {
+            return Err(CtlError::InvalidLength {
+                expected: 1,
+                actual: tlv.value.len(),
+            });
+        }
+        Ok(tlv.value[0])
+    }
+
+    /// Adjust UI chip output volume and return the updated value.
+    pub async fn ui_adjust_volume(
+        &mut self,
+        direction: AdjDirection,
+        amount: u8,
+    ) -> Result<u8, CtlError> {
+        self.write_tlv_ui(CtlToUi::AdjVolume, &[direction as u8, amount])
+            .await?;
+        let tlv = self.read_tlv_ui_skip_log().await?;
+        if tlv.tlv_type != UiToCtl::Volume {
+            return Err(CtlError::UnexpectedResponse {
+                expected: "Volume",
+                actual: format!("{:?}", tlv.tlv_type),
+            });
+        }
+        if tlv.value.len() != 1 {
+            return Err(CtlError::InvalidLength {
+                expected: 1,
+                actual: tlv.value.len(),
+            });
+        }
+        Ok(tlv.value[0])
+    }
+
+    /// Get UI chip microphone preamp level.
+    pub async fn ui_get_mic_preamp(&mut self) -> Result<u8, CtlError> {
+        self.write_tlv_ui(CtlToUi::GetMicPreamp, &[]).await?;
+        let tlv = self.read_tlv_ui_skip_log().await?;
+        if tlv.tlv_type != UiToCtl::MicPreamp {
+            return Err(CtlError::UnexpectedResponse {
+                expected: "MicPreamp",
+                actual: format!("{:?}", tlv.tlv_type),
+            });
+        }
+        if tlv.value.len() != 1 {
+            return Err(CtlError::InvalidLength {
+                expected: 1,
+                actual: tlv.value.len(),
+            });
+        }
+        Ok(tlv.value[0])
+    }
+
+    /// Set UI chip microphone preamp level.
+    pub async fn ui_set_mic_preamp(&mut self, preamp: u8) -> Result<u8, CtlError> {
+        self.write_tlv_ui(CtlToUi::SetMicPreamp, &[preamp]).await?;
+        let tlv = self.read_tlv_ui_skip_log().await?;
+        if tlv.tlv_type != UiToCtl::MicPreamp {
+            return Err(CtlError::UnexpectedResponse {
+                expected: "MicPreamp",
+                actual: format!("{:?}", tlv.tlv_type),
+            });
+        }
+        if tlv.value.len() != 1 {
+            return Err(CtlError::InvalidLength {
+                expected: 1,
+                actual: tlv.value.len(),
+            });
+        }
+        Ok(tlv.value[0])
+    }
+
+    /// Adjust UI chip microphone preamp level and return the updated value.
+    pub async fn ui_adjust_mic_preamp(
+        &mut self,
+        direction: AdjDirection,
+        amount: u8,
+    ) -> Result<u8, CtlError> {
+        self.write_tlv_ui(CtlToUi::AdjMicPreamp, &[direction as u8, amount])
+            .await?;
+        let tlv = self.read_tlv_ui_skip_log().await?;
+        if tlv.tlv_type != UiToCtl::MicPreamp {
+            return Err(CtlError::UnexpectedResponse {
+                expected: "MicPreamp",
+                actual: format!("{:?}", tlv.tlv_type),
+            });
+        }
+        if tlv.value.len() != 1 {
+            return Err(CtlError::InvalidLength {
+                expected: 1,
+                actual: tlv.value.len(),
+            });
+        }
+        Ok(tlv.value[0])
     }
 
     /// Set UI chip BOOT0 pin directly.

--- a/link/src/lib.rs
+++ b/link/src/lib.rs
@@ -52,8 +52,8 @@ pub use shared::wifi::WifiSsid;
 
 // Re-export protocol types
 pub use shared::protocol::{
-    ChannelId, CtlToMgmt, CtlToNet, CtlToUi, MgmtToCtl, NetLoopbackMode, NetToCtl, NetToUi, Pin,
-    PinValue, StackInfo, UiLoopbackMode, UiToCtl, UiToNet,
+    AdjDirection, ChannelId, CtlToMgmt, CtlToNet, CtlToUi, MgmtToCtl, NetLoopbackMode, NetToCtl,
+    NetToUi, Pin, PinValue, StackInfo, UiLoopbackMode, UiToCtl, UiToNet,
 };
 
 // Re-export logging macros (crate-internal, no-op when defmt disabled)

--- a/link/src/shared/protocol.rs
+++ b/link/src/shared/protocol.rs
@@ -97,6 +97,15 @@ impl core::fmt::Display for NetLoopbackMode {
     }
 }
 
+/// Volume adjustment direction for the UI chip.
+#[derive(Copy, Clone, PartialEq, Eq, Debug, IntoPrimitive, TryFromPrimitive)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[repr(u8)]
+pub enum AdjDirection {
+    Down = 0,
+    Up,
+}
+
 /// Pin identifiers for SetPin command.
 #[derive(Copy, Clone, PartialEq, Eq, Debug, IntoPrimitive, TryFromPrimitive)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
@@ -169,10 +178,10 @@ pub enum CtlToUi {
     SetVersion,
     GetSFrameKey,
     SetSFrameKey,
-    /// Set loopback mode (1 byte: UiLoopbackMode)
-    SetLoopback,
     /// Get loopback mode
     GetLoopback,
+    /// Set loopback mode (1 byte: UiLoopbackMode)
+    SetLoopback,
     /// Get stack usage information
     GetStackInfo,
     /// Repaint the stack with the paint pattern
@@ -187,6 +196,14 @@ pub enum CtlToUi {
     GetVolume,
     /// Set output volume (1 byte: u8)
     SetVolume,
+    /// Adjust output volume (2 bytes: AdjVolume, amount)
+    AdjVolume,
+    /// Get microphone preamp level (returns 1 byte: u8)
+    GetMicPreamp,
+    /// Set microphone preamp level (1 byte: u8)
+    SetMicPreamp,
+    /// Adjust microphone preamp level (2 bytes: AdjMicPreamp, amount)
+    AdjMicPreamp,
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, IntoPrimitive, TryFromPrimitive)]
@@ -208,6 +225,8 @@ pub enum UiToCtl {
     LogsEnabled,
     /// Output volume (1 byte: u8)
     Volume,
+    /// Microphone preamp level (1 byte: u8)
+    MicPreamp,
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, IntoPrimitive, TryFromPrimitive)]

--- a/link/src/ui/mod.rs
+++ b/link/src/ui/mod.rs
@@ -15,8 +15,8 @@ pub use log::{LogMessage, LogSender, MAX_LOG_SIZE};
 
 use crate::info;
 use crate::shared::{
-    Channel, ChannelId, Color, CriticalSectionRawMutex, CtlToUi, Led, NetToUi, Sender,
-    StackMonitor, Tlv, UiLoopbackMode, UiToCtl, UiToNet, WriteTlv, chunk, read_tlv_loop,
+    AdjDirection, Channel, ChannelId, Color, CriticalSectionRawMutex, CtlToUi, Led, NetToUi,
+    Sender, StackMonitor, Tlv, UiLoopbackMode, UiToCtl, UiToNet, WriteTlv, chunk, read_tlv_loop,
 };
 
 /// Board trait for UI chip.
@@ -114,6 +114,9 @@ where
     // Shared volume level (TODO: actually configure the audio system)
     let volume = AtomicU8::new(255);
 
+    // Shared microphone preamp level (TODO: actually configure the audio system)
+    let mic_preamp = AtomicU8::new(255);
+
     // Shared button state - true when any button is pressed
     // This allows audio_task to skip sending frames when no button is held
     let button_active = AtomicBool::new(false);
@@ -143,6 +146,7 @@ where
                         &loopback_mode,
                         &logs_enabled,
                         &volume,
+                        &mic_preamp,
                         &mut sframe_state,
                         &board,
                     )
@@ -391,6 +395,7 @@ async fn handle_mgmt<M, N, I, D, B>(
     loopback_mode: &AtomicU8,
     logs_enabled: &AtomicBool,
     volume: &AtomicU8,
+    mic_preamp: &AtomicU8,
     sframe_state: &mut sframe::SFrameState,
     board: &B,
 ) where
@@ -538,6 +543,76 @@ async fn handle_mgmt<M, N, I, D, B>(
             info!("ui: set volume = {}", vol);
             volume.store(vol, Ordering::Relaxed);
             to_mgmt.must_write_tlv(UiToCtl::Ack, &[]).await;
+        }
+        CtlToUi::AdjVolume => {
+            if tlv.value.len() != 2 {
+                info!(
+                    "ui: invalid adjust volume payload length: {}",
+                    tlv.value.len()
+                );
+                to_mgmt.must_write_tlv(UiToCtl::Error, b"volume").await;
+                return;
+            }
+
+            let Ok(direction) = AdjDirection::try_from(tlv.value[0]) else {
+                info!("ui: invalid adjust volume direction: {}", tlv.value[0]);
+                to_mgmt.must_write_tlv(UiToCtl::Error, b"volume").await;
+                return;
+            };
+
+            let amount = tlv.value[1];
+            let current = volume.load(Ordering::Relaxed);
+            let next = match direction {
+                AdjDirection::Down => current.saturating_sub(amount),
+                AdjDirection::Up => current.saturating_add(amount),
+            };
+            volume.store(next, Ordering::Relaxed);
+            to_mgmt.must_write_tlv(UiToCtl::Volume, &[next]).await;
+        }
+        CtlToUi::GetMicPreamp => {
+            let preamp = mic_preamp.load(Ordering::Relaxed);
+            info!("ui: get mic preamp = {}", preamp);
+            to_mgmt.must_write_tlv(UiToCtl::MicPreamp, &[preamp]).await;
+        }
+        CtlToUi::SetMicPreamp => {
+            if tlv.value.len() != 1 {
+                info!(
+                    "ui: invalid set mic preamp payload length: {}",
+                    tlv.value.len()
+                );
+                to_mgmt.must_write_tlv(UiToCtl::Error, b"mic-preamp").await;
+                return;
+            }
+
+            let preamp = tlv.value[0];
+            info!("ui: set mic preamp = {}", preamp);
+            mic_preamp.store(preamp, Ordering::Relaxed);
+            to_mgmt.must_write_tlv(UiToCtl::Ack, &[]).await;
+        }
+        CtlToUi::AdjMicPreamp => {
+            if tlv.value.len() != 2 {
+                info!(
+                    "ui: invalid adjust mic preamp payload length: {}",
+                    tlv.value.len()
+                );
+                to_mgmt.must_write_tlv(UiToCtl::Error, b"mic-preamp").await;
+                return;
+            }
+
+            let Ok(direction) = AdjDirection::try_from(tlv.value[0]) else {
+                info!("ui: invalid adjust mic preamp direction: {}", tlv.value[0]);
+                to_mgmt.must_write_tlv(UiToCtl::Error, b"mic-preamp").await;
+                return;
+            };
+
+            let amount = tlv.value[1];
+            let current = mic_preamp.load(Ordering::Relaxed);
+            let next = match direction {
+                AdjDirection::Down => current.saturating_sub(amount),
+                AdjDirection::Up => current.saturating_add(amount),
+            };
+            mic_preamp.store(next, Ordering::Relaxed);
+            to_mgmt.must_write_tlv(UiToCtl::MicPreamp, &[next]).await;
         }
     }
 }

--- a/link/src/ui/mod.rs
+++ b/link/src/ui/mod.rs
@@ -701,6 +701,7 @@ mod tests {
         let loopback_mode = AtomicU8::new(UiLoopbackMode::Off as u8);
         let logs_enabled = AtomicBool::new(true);
         let volume = AtomicU8::new(255);
+        let mic_preamp = AtomicU8::new(255);
         let mut sframe_state = sframe::SFrameState::new(&[0u8; 16], 0);
         handle_mgmt(
             tlv,
@@ -711,6 +712,7 @@ mod tests {
             &loopback_mode,
             &logs_enabled,
             &volume,
+            &mic_preamp,
             &mut sframe_state,
             &crate::shared::NoOpBoard,
         )
@@ -740,6 +742,7 @@ mod tests {
         let loopback_mode = AtomicU8::new(UiLoopbackMode::Off as u8);
         let logs_enabled = AtomicBool::new(true);
         let volume = AtomicU8::new(255);
+        let mic_preamp = AtomicU8::new(255);
         let mut sframe_state = sframe::SFrameState::new(&[0u8; 16], 0);
         handle_mgmt(
             tlv,
@@ -750,6 +753,7 @@ mod tests {
             &loopback_mode,
             &logs_enabled,
             &volume,
+            &mic_preamp,
             &mut sframe_state,
             &crate::shared::NoOpBoard,
         )
@@ -785,6 +789,7 @@ mod tests {
         let loopback_mode = AtomicU8::new(UiLoopbackMode::Off as u8);
         let logs_enabled = AtomicBool::new(true);
         let volume = AtomicU8::new(255);
+        let mic_preamp = AtomicU8::new(255);
         let mut sframe_state = sframe::SFrameState::new(&[0u8; 16], 0);
         handle_mgmt(
             tlv,
@@ -795,6 +800,7 @@ mod tests {
             &loopback_mode,
             &logs_enabled,
             &volume,
+            &mic_preamp,
             &mut sframe_state,
             &crate::shared::NoOpBoard,
         )
@@ -827,6 +833,7 @@ mod tests {
         let loopback_mode = AtomicU8::new(UiLoopbackMode::Off as u8);
         let logs_enabled = AtomicBool::new(true);
         let volume = AtomicU8::new(255);
+        let mic_preamp = AtomicU8::new(255);
         let mut sframe_state = sframe::SFrameState::new(&[0u8; 16], 0);
         handle_mgmt(
             tlv,
@@ -837,6 +844,7 @@ mod tests {
             &loopback_mode,
             &logs_enabled,
             &volume,
+            &mic_preamp,
             &mut sframe_state,
             &crate::shared::NoOpBoard,
         )
@@ -867,6 +875,7 @@ mod tests {
         let loopback_mode = AtomicU8::new(UiLoopbackMode::Off as u8);
         let logs_enabled = AtomicBool::new(true);
         let volume = AtomicU8::new(255);
+        let mic_preamp = AtomicU8::new(255);
         let mut sframe_state = sframe::SFrameState::new(&[0u8; 16], 0);
         handle_mgmt(
             tlv,
@@ -877,6 +886,7 @@ mod tests {
             &loopback_mode,
             &logs_enabled,
             &volume,
+            &mic_preamp,
             &mut sframe_state,
             &crate::shared::NoOpBoard,
         )
@@ -907,6 +917,7 @@ mod tests {
         let loopback_mode = AtomicU8::new(UiLoopbackMode::Off as u8);
         let logs_enabled = AtomicBool::new(true);
         let volume = AtomicU8::new(255);
+        let mic_preamp = AtomicU8::new(255);
         let mut sframe_state = sframe::SFrameState::new(&[0u8; 16], 0);
         handle_mgmt(
             tlv,
@@ -917,6 +928,7 @@ mod tests {
             &loopback_mode,
             &logs_enabled,
             &volume,
+            &mic_preamp,
             &mut sframe_state,
             &crate::shared::NoOpBoard,
         )


### PR DESCRIPTION
Changes:
- Adds `get`, `set`, `up`, and `down` actions for UI volume.
- Adds `mic-preamp` commands in `ctl` with the same actions.
- Extends the shared TLV protocol with volume-adjust and mic-preamp message types.
- Updates UI firmware to store, return, and adjust mic preamp and volume values.
- Updates CTL core to send these commands and read back the resulting values.
- Switches MGMT-side TLV reads in CTL to buffered parsing so tunneled UI responses are handled reliably.
