### PR TITLE
Add ui ping handshake dance to audio recordings

### DIFF
--- a/ctl/src/handlers/ui.rs
+++ b/ctl/src/handlers/ui.rs
@@ -481,14 +481,8 @@ async fn capture_live(core: &mut Core) -> Result<(), Box<dyn std::error::Error>>
     use rubato::{FftFixedIn, Resampler};
     use std::sync::{Arc, Mutex};
 
-    println!("Pinging ui until its ready");
-    match ping_ui_until_pong(core).await {
-        Ok(()) => {}
-        Err(err) => {
-            println!("Failed to ping ui");
-            return Err(err);
-        }
-    }
+    // Ping the ui until it responds or times out.
+    core.ping_ui_until_pong().await?;
 
     // Get the SFrame key from UI chip
     println!("Reading SFrame key from UI chip...");
@@ -805,42 +799,11 @@ fn save_wav_file(
     Ok(filename)
 }
 
-async fn ping_ui_until_pong(core: &mut Core) -> Result<(), Box<dyn std::error::Error>> {
-    let original_timeout = core.port_mut().timeout();
-    let ping_data = b"hello";
-
-    // Need to wait for net to stop dumping logs
-    core.port_mut().set_timeout(Duration::from_millis(1000))?;
-
-    for _ in 0..10 {
-        match core.ui_ping(ping_data).await {
-            Ok(()) => {
-                core.port_mut().set_timeout(original_timeout)?;
-                return Ok(());
-            }
-            Err(err) => {
-                println!("Ping failed {err}");
-                continue;
-            }
-        }
-    }
-
-    core.port_mut().set_timeout(original_timeout)?;
-    Err("Ui did not respond to ping after 10 attempts".into())
-}
-
 /// Capture audio from the UI chip and save to numbered WAV files.
 /// Each PTT press creates a new file: basename_001.wav, basename_002.wav, etc.
 async fn capture_wav(core: &mut Core, basename: &str) -> Result<(), Box<dyn std::error::Error>> {
     // Ping the ui until it responds or times out.
-    println!("Pinging ui until its ready");
-    match ping_ui_until_pong(core).await {
-        Ok(()) => {}
-        Err(err) => {
-            println!("Failed to ping ui");
-            return Err(err);
-        }
-    }
+    core.ping_ui_until_pong().await?;
 
     // Get the SFrame key from UI chip
     println!("Reading SFrame key from UI chip...");
@@ -1051,14 +1014,8 @@ async fn play_wav(
         samples.len()
     );
 
-    println!("Pinging ui until its ready");
-    match ping_ui_until_pong(core).await {
-        Ok(()) => {}
-        Err(err) => {
-            println!("Failed to ping ui");
-            return Err(err);
-        }
-    }
+    // Ping the ui until it responds or times out.
+    core.ping_ui_until_pong().await?;
 
     // Get the SFrame key from UI chip
     println!("Reading SFrame key from UI chip...");
@@ -1116,14 +1073,8 @@ async fn play_live(core: &mut Core) -> Result<(), Box<dyn std::error::Error>> {
     use std::sync::Arc;
     use std::sync::atomic::{AtomicBool, Ordering};
 
-    println!("Pinging ui until its ready");
-    match ping_ui_until_pong(core).await {
-        Ok(()) => {}
-        Err(err) => {
-            println!("Failed to ping ui");
-            return Err(err);
-        }
-    }
+    // Ping the ui until it responds or times out.
+    core.ping_ui_until_pong().await?;
 
     // Get the SFrame key from UI chip
     println!("Reading SFrame key from UI chip...");

--- a/ctl/src/handlers/ui.rs
+++ b/ctl/src/handlers/ui.rs
@@ -796,9 +796,43 @@ fn save_wav_file(
     Ok(filename)
 }
 
+async fn ping_ui_until_pong(core: &mut Core) -> Result<(), Box<dyn std::error::Error>> {
+    let original_timeout = core.port_mut().timeout();
+    let ping_data = b"hello";
+
+    // Need to wait for net to stop dumping logs
+    core.port_mut().set_timeout(Duration::from_millis(1000))?;
+
+    for _ in 0..10 {
+        match core.ui_ping(ping_data).await {
+            Ok(()) => {
+                core.port_mut().set_timeout(original_timeout)?;
+                return Ok(());
+            }
+            Err(err) => {
+                println!("Ping failed {err}");
+                continue;
+            }
+        }
+    }
+
+    core.port_mut().set_timeout(original_timeout)?;
+    Err("Ui did not respond to ping after 10 attempts".into())
+}
+
 /// Capture audio from the UI chip and save to numbered WAV files.
 /// Each PTT press creates a new file: basename_001.wav, basename_002.wav, etc.
 async fn capture_wav(core: &mut Core, basename: &str) -> Result<(), Box<dyn std::error::Error>> {
+    // Ping the ui until it responds or times out.
+    println!("Pinging ui until its ready");
+    match ping_ui_until_pong(core).await {
+        Ok(()) => {}
+        Err(err) => {
+            println!("Failed to ping ui");
+            return Err(err);
+        }
+    }
+
     // Get the SFrame key from UI chip
     println!("Reading SFrame key from UI chip...");
     let sframe_key = core.get_sframe_key().await?;

--- a/ctl/src/handlers/ui.rs
+++ b/ctl/src/handlers/ui.rs
@@ -481,6 +481,15 @@ async fn capture_live(core: &mut Core) -> Result<(), Box<dyn std::error::Error>>
     use rubato::{FftFixedIn, Resampler};
     use std::sync::{Arc, Mutex};
 
+    println!("Pinging ui until its ready");
+    match ping_ui_until_pong(core).await {
+        Ok(()) => {}
+        Err(err) => {
+            println!("Failed to ping ui");
+            return Err(err);
+        }
+    }
+
     // Get the SFrame key from UI chip
     println!("Reading SFrame key from UI chip...");
     let sframe_key = core.get_sframe_key().await?;
@@ -1042,6 +1051,15 @@ async fn play_wav(
         samples.len()
     );
 
+    println!("Pinging ui until its ready");
+    match ping_ui_until_pong(core).await {
+        Ok(()) => {}
+        Err(err) => {
+            println!("Failed to ping ui");
+            return Err(err);
+        }
+    }
+
     // Get the SFrame key from UI chip
     println!("Reading SFrame key from UI chip...");
     let sframe_key = core.get_sframe_key().await?;
@@ -1097,6 +1115,15 @@ async fn play_live(core: &mut Core) -> Result<(), Box<dyn std::error::Error>> {
     use rubato::{FftFixedIn, Resampler};
     use std::sync::Arc;
     use std::sync::atomic::{AtomicBool, Ordering};
+
+    println!("Pinging ui until its ready");
+    match ping_ui_until_pong(core).await {
+        Ok(()) => {}
+        Err(err) => {
+            println!("Failed to ping ui");
+            return Err(err);
+        }
+    }
 
     // Get the SFrame key from UI chip
     println!("Reading SFrame key from UI chip...");

--- a/link/src/ctl/core.rs
+++ b/link/src/ctl/core.rs
@@ -416,7 +416,7 @@ impl<P: CtlPort> CtlCore<P> {
         let _ = self.port_mut().write_rts(false).await;
         delay_ms(50).await;
         let _ = self.port_mut().write_dtr(false).await;
-        delay_ms(100).await;
+        delay_ms(200).await;
     }
 
     /// Send Hello handshake to detect if a valid device is connected.

--- a/link/src/ctl/core.rs
+++ b/link/src/ctl/core.rs
@@ -661,6 +661,25 @@ impl<P: CtlPort> CtlCore<P> {
         Ok(())
     }
 
+    pub async fn ping_ui_until_pong(&mut self) -> Result<(), CtlError> {
+        let ping_data = b"hello";
+        // Need to wait for net to stop dumping logs
+        for i in 0..10 {
+            println!("Pinging UI until Pong {}/10", i + 1);
+            match self.ui_ping(ping_data).await {
+                Ok(()) => {
+                    return Ok(());
+                }
+                Err(err) => {
+                    println!("Ping failed {err}");
+                    continue;
+                }
+            }
+        }
+
+        Err(CtlError::Timeout)
+    }
+
     /// Get the version stored in UI chip EEPROM.
     pub async fn get_version(&mut self) -> Result<u32, CtlError> {
         self.write_tlv_ui(CtlToUi::GetVersion, &[]).await?;


### PR DESCRIPTION
The net chip was talking too much which was causing some odd issues related to trying to get the sframe and it would just hang there. So to ensure that we can get the bytes we need from ui we ping it until it is ready.