### PR TITLE
Increased the delay after resetting the port

### DIFF
--- a/link/src/ctl/core.rs
+++ b/link/src/ctl/core.rs
@@ -416,7 +416,7 @@ impl<P: CtlPort> CtlCore<P> {
         let _ = self.port_mut().write_rts(false).await;
         delay_ms(50).await;
         let _ = self.port_mut().write_dtr(false).await;
-        delay_ms(100).await;
+        delay_ms(200).await;
     }
 
     /// Send Hello handshake to detect if a valid device is connected.


### PR DESCRIPTION
Sometimes the hactar on C wouldn't be detected, so I increased the amount of time after the mgmt has been reset to give the UI time to actually boot up and ready to listen. 

With this change I am no longer having issues just getting the ctl to discover the ui chip.