### PR TITLE
Added additional enum for audio mode

### DIFF
--- a/link/src/shared/protocol.rs
+++ b/link/src/shared/protocol.rs
@@ -83,7 +83,8 @@ pub enum AudioMode {
     #[default]
     Net = 0,
     /// Audio routed to/from CTL via MGMT (for capture/playback testing)
-    Ctl = 1,
+    Ctl,
+    Both,
 }
 
 impl core::fmt::Display for AudioMode {
@@ -91,6 +92,7 @@ impl core::fmt::Display for AudioMode {
         match self {
             AudioMode::Net => write!(f, "net"),
             AudioMode::Ctl => write!(f, "ctl"),
+            AudioMode::Both => write!(f, "both"),
         }
     }
 }


### PR DESCRIPTION
Right now we can send our sframe audio to net or to mgmt, but not both. I added an additional variant for that.