### PR TITLE
Added merged monitors for the ui and net

### DIFF
--- a/ctl/src/handlers/mod.rs
+++ b/ctl/src/handlers/mod.rs
@@ -6,7 +6,7 @@ mod ui;
 
 pub use mgmt::handle_mgmt;
 pub use net::handle_net;
-pub use ui::{handle_audio, handle_ui};
+pub use ui::{handle_audio, handle_monitor, handle_ui};
 
 /// Re-export Core type for handlers.
 pub type Core = crate::Core;

--- a/ctl/src/handlers/net.rs
+++ b/ctl/src/handlers/net.rs
@@ -6,8 +6,8 @@ use crate::{
     ResetAction, WifiAction,
 };
 use indicatif::{ProgressBar, ProgressStyle};
-use link::ctl::flash::StdDelay;
 use link::ctl::ProgressCallbacks;
+use link::ctl::flash::StdDelay;
 use link::{NetLoopbackMode, Pin, PinValue};
 use std::io::Write;
 

--- a/ctl/src/handlers/net.rs
+++ b/ctl/src/handlers/net.rs
@@ -7,8 +7,7 @@ use crate::{
 };
 use indicatif::{ProgressBar, ProgressStyle};
 use link::ctl::flash::StdDelay;
-use link::ctl::{ProgressCallbacks, SetTimeout, escape_non_ascii};
-use link::protocol_config::timeouts;
+use link::ctl::ProgressCallbacks;
 use link::{NetLoopbackMode, Pin, PinValue};
 use std::io::Write;
 
@@ -325,79 +324,6 @@ pub async fn handle_net(
                 }
                 Err(e) => Err(format!("Failed to erase flash: {}", e).into()),
             }
-        }
-        NetAction::Monitor { reset } => {
-            if reset {
-                println!("Resetting NET chip...");
-                let delay = |ms| tokio::time::sleep(std::time::Duration::from_millis(ms));
-                core.reset_net_to_user(delay).await?;
-            }
-            println!("Monitoring NET chip (ESC to stop)...\n");
-
-            // Set a short timeout for non-blocking reads
-            if let Err(e) = core
-                .port_mut()
-                .set_timeout(std::time::Duration::from_millis(timeouts::MONITOR_MS))
-            {
-                eprintln!("Warning: couldn't set timeout: {}", e);
-            }
-
-            use crossterm::event::{self, Event, KeyCode, KeyEvent};
-            use crossterm::terminal;
-            use std::io::Write;
-
-            // Enable raw mode to capture ESC
-            terminal::enable_raw_mode()?;
-
-            let result = async {
-                loop {
-                    // Check for key press (non-blocking)
-                    if event::poll(std::time::Duration::from_millis(0))? {
-                        if let Event::Key(KeyEvent {
-                            code: KeyCode::Esc, ..
-                        }) = event::read()?
-                        {
-                            return Ok::<(), Box<dyn std::error::Error>>(());
-                        }
-                    }
-
-                    // Check for TLV data (timeout-aware: returns Ok(None) on timeout)
-                    match core.read_tlv_raw().await {
-                        Ok(Some(tlv)) => {
-                            if tlv.tlv_type == link::MgmtToCtl::FromNet {
-                                let text = escape_non_ascii(&tlv.value);
-                                print!("{}", text);
-                                std::io::stdout().flush().ok();
-                            }
-                        }
-                        Ok(None) => {
-                            // Timeout, continue
-                        }
-                        Err(e) => {
-                            if e.is_timeout() {
-                                continue;
-                            }
-                            return Err(format!("Read error: {:?}", e).into());
-                        }
-                    }
-                }
-            }
-            .await;
-
-            // Always restore terminal mode and timeout
-            terminal::disable_raw_mode()?;
-
-            // Restore timeout to normal
-            if let Err(e) = core
-                .port_mut()
-                .set_timeout(std::time::Duration::from_secs(timeouts::NORMAL_SECS))
-            {
-                eprintln!("Warning: couldn't restore timeout: {}", e);
-            }
-
-            println!("\nMonitor stopped.");
-
-            result
         }
         NetAction::Logs { action } => match action.unwrap_or_default() {
             LogsAction::Get => {

--- a/ctl/src/handlers/ui.rs
+++ b/ctl/src/handlers/ui.rs
@@ -3,8 +3,7 @@
 use super::Core;
 use crate::{
     AudioAction, AudioModeAction, CaptureMode, GetSetHex, GetSetU32, LogsAction, LoopbackAction,
-    MonitorTarget, PinAction, PinLevel, PlayMode, ResetAction, StackAction, UiAction,
-    VolumeAction,
+    MonitorTarget, PinAction, PinLevel, PlayMode, ResetAction, StackAction, UiAction, VolumeAction,
 };
 use indicatif::{ProgressBar, ProgressStyle};
 use link::ctl::SetTimeout;

--- a/ctl/src/handlers/ui.rs
+++ b/ctl/src/handlers/ui.rs
@@ -3,7 +3,8 @@
 use super::Core;
 use crate::{
     AudioAction, AudioModeAction, CaptureMode, GetSetHex, GetSetU32, LogsAction, LoopbackAction,
-    PinAction, PinLevel, PlayMode, ResetAction, StackAction, UiAction, VolumeAction,
+    MonitorTarget, PinAction, PinLevel, PlayMode, ResetAction, StackAction, UiAction,
+    VolumeAction,
 };
 use indicatif::{ProgressBar, ProgressStyle};
 use link::ctl::SetTimeout;
@@ -260,76 +261,6 @@ pub async fn handle_ui(
                 Ok(())
             }
         },
-        UiAction::Monitor { reset } => {
-            if reset {
-                println!("Resetting UI chip...");
-                let delay = |ms| tokio::time::sleep(Duration::from_millis(ms));
-                core.reset_ui_to_user(delay).await?;
-            }
-            println!("Monitoring UI chip logs (ESC to stop)...\n");
-
-            // Set a short timeout for non-blocking reads
-            if let Err(e) = core
-                .port_mut()
-                .set_timeout(Duration::from_millis(timeouts::MONITOR_MS))
-            {
-                eprintln!("Warning: couldn't set timeout: {}", e);
-            }
-
-            use crossterm::event::{self, Event, KeyCode, KeyEvent};
-            use crossterm::terminal;
-
-            // Enable raw mode to capture ESC
-            terminal::enable_raw_mode()?;
-
-            let result = async {
-                loop {
-                    // Check for key press (non-blocking)
-                    if event::poll(Duration::from_millis(0))? {
-                        if let Event::Key(KeyEvent {
-                            code: KeyCode::Esc, ..
-                        }) = event::read()?
-                        {
-                            return Ok::<(), Box<dyn std::error::Error>>(());
-                        }
-                    }
-
-                    // Check for TLV data from UI (timeout-aware)
-                    match core.try_read_ui_log().await {
-                        Ok(Some(msg)) => {
-                            // Use \r\n for raw terminal mode
-                            print!("[UI] {}\r\n", msg);
-                            std::io::stdout().flush().ok();
-                        }
-                        Ok(None) => {
-                            // Timeout or non-log TLV, continue
-                        }
-                        Err(e) => {
-                            if e.is_timeout() {
-                                continue;
-                            }
-                            return Err(format!("Read error: {:?}", e).into());
-                        }
-                    }
-                }
-            }
-            .await;
-
-            // Always restore terminal mode and timeout
-            terminal::disable_raw_mode()?;
-
-            // Restore timeout to normal
-            if let Err(e) = core
-                .port_mut()
-                .set_timeout(Duration::from_secs(timeouts::NORMAL_SECS))
-            {
-                eprintln!("Warning: couldn't restore timeout: {}", e);
-            }
-
-            println!("\nMonitor stopped.");
-
-            result
-        }
         UiAction::Stack { action } => match action.unwrap_or_default() {
             StackAction::Info => {
                 let info = core.ui_get_stack_info().await?;
@@ -449,19 +380,29 @@ pub async fn handle_ui(
 }
 
 pub async fn handle_monitor(
+    target: MonitorTarget,
     reset: bool,
     core: &mut Core,
 ) -> Result<(), Box<dyn std::error::Error>> {
     if reset {
-        println!("Resetting UI chip...");
-        let delay = |ms| tokio::time::sleep(Duration::from_millis(ms));
-        core.reset_ui_to_user(delay).await?;
+        if matches!(target, MonitorTarget::Ui | MonitorTarget::Both) {
+            println!("Resetting UI chip...");
+            let delay = |ms| tokio::time::sleep(Duration::from_millis(ms));
+            core.reset_ui_to_user(delay).await?;
+        }
 
-        println!("Resetting NET chip...");
-        let delay = |ms| tokio::time::sleep(Duration::from_millis(ms));
-        core.reset_net_to_user(delay).await?;
+        if matches!(target, MonitorTarget::Net | MonitorTarget::Both) {
+            println!("Resetting NET chip...");
+            let delay = |ms| tokio::time::sleep(Duration::from_millis(ms));
+            core.reset_net_to_user(delay).await?;
+        }
     }
-    println!("Monitoring UI and NET logs (ESC to stop)...\n");
+
+    match target {
+        MonitorTarget::Ui => println!("Monitoring UI logs (ESC to stop)...\n"),
+        MonitorTarget::Net => println!("Monitoring NET logs (ESC to stop)...\n"),
+        MonitorTarget::Both => println!("Monitoring UI and NET logs (ESC to stop)...\n"),
+    }
 
     if let Err(e) = core
         .port_mut()
@@ -486,23 +427,54 @@ pub async fn handle_monitor(
                 }
             }
 
-            match core.try_read_monitor_event().await {
-                Ok(Some(MonitorEvent::UiLog(msg))) => {
-                    print!("[UI] {}\r\n", msg);
-                    std::io::stdout().flush().ok();
-                }
-                Ok(Some(MonitorEvent::NetData(data))) => {
-                    let text = escape_non_ascii(&data);
-                    print!("[NET] {}", text);
-                    std::io::stdout().flush().ok();
-                }
-                Ok(None) => {}
-                Err(e) => {
-                    if e.is_timeout() {
-                        continue;
+            match target {
+                MonitorTarget::Ui => match core.try_read_ui_log().await {
+                    Ok(Some(msg)) => {
+                        print!("[UI] {}\r\n", msg);
+                        std::io::stdout().flush().ok();
                     }
-                    return Err(format!("Read error: {:?}", e).into());
-                }
+                    Ok(None) => {}
+                    Err(e) => {
+                        if e.is_timeout() {
+                            continue;
+                        }
+                        return Err(format!("Read error: {:?}", e).into());
+                    }
+                },
+                MonitorTarget::Net => match core.read_tlv_raw().await {
+                    Ok(Some(tlv)) => {
+                        if tlv.tlv_type == link::MgmtToCtl::FromNet {
+                            let text = escape_non_ascii(&tlv.value);
+                            print!("[NET] {}", text);
+                            std::io::stdout().flush().ok();
+                        }
+                    }
+                    Ok(None) => {}
+                    Err(e) => {
+                        if e.is_timeout() {
+                            continue;
+                        }
+                        return Err(format!("Read error: {:?}", e).into());
+                    }
+                },
+                MonitorTarget::Both => match core.try_read_monitor_event().await {
+                    Ok(Some(MonitorEvent::UiLog(msg))) => {
+                        print!("[UI] {}\r\n", msg);
+                        std::io::stdout().flush().ok();
+                    }
+                    Ok(Some(MonitorEvent::NetData(data))) => {
+                        let text = escape_non_ascii(&data);
+                        print!("[NET] {}", text);
+                        std::io::stdout().flush().ok();
+                    }
+                    Ok(None) => {}
+                    Err(e) => {
+                        if e.is_timeout() {
+                            continue;
+                        }
+                        return Err(format!("Read error: {:?}", e).into());
+                    }
+                },
             }
         }
     }

--- a/ctl/src/handlers/ui.rs
+++ b/ctl/src/handlers/ui.rs
@@ -9,6 +9,7 @@ use indicatif::{ProgressBar, ProgressStyle};
 use link::ctl::SetTimeout;
 use link::ctl::audio_capture::{AudioSink, CaptureSession, PlaybackSession};
 use link::ctl::flash::FlashPhase;
+use link::ctl::{MonitorEvent, escape_non_ascii};
 use link::protocol_config::timeouts;
 use link::{AdjDirection, AudioMode, PinValue, UiLoopbackMode, UiToCtl};
 use std::io::Write;
@@ -445,6 +446,80 @@ pub async fn handle_ui(
             }
         },
     }
+}
+
+pub async fn handle_monitor(
+    reset: bool,
+    core: &mut Core,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if reset {
+        println!("Resetting UI chip...");
+        let delay = |ms| tokio::time::sleep(Duration::from_millis(ms));
+        core.reset_ui_to_user(delay).await?;
+
+        println!("Resetting NET chip...");
+        let delay = |ms| tokio::time::sleep(Duration::from_millis(ms));
+        core.reset_net_to_user(delay).await?;
+    }
+    println!("Monitoring UI and NET logs (ESC to stop)...\n");
+
+    if let Err(e) = core
+        .port_mut()
+        .set_timeout(Duration::from_millis(timeouts::MONITOR_MS))
+    {
+        eprintln!("Warning: couldn't set timeout: {}", e);
+    }
+
+    use crossterm::event::{self, Event, KeyCode, KeyEvent};
+    use crossterm::terminal;
+
+    terminal::enable_raw_mode()?;
+
+    let result = async {
+        loop {
+            if event::poll(Duration::from_millis(0))? {
+                if let Event::Key(KeyEvent {
+                    code: KeyCode::Esc, ..
+                }) = event::read()?
+                {
+                    return Ok::<(), Box<dyn std::error::Error>>(());
+                }
+            }
+
+            match core.try_read_monitor_event().await {
+                Ok(Some(MonitorEvent::UiLog(msg))) => {
+                    print!("[UI] {}\r\n", msg);
+                    std::io::stdout().flush().ok();
+                }
+                Ok(Some(MonitorEvent::NetData(data))) => {
+                    let text = escape_non_ascii(&data);
+                    print!("[NET] {}", text);
+                    std::io::stdout().flush().ok();
+                }
+                Ok(None) => {}
+                Err(e) => {
+                    if e.is_timeout() {
+                        continue;
+                    }
+                    return Err(format!("Read error: {:?}", e).into());
+                }
+            }
+        }
+    }
+    .await;
+
+    terminal::disable_raw_mode()?;
+
+    if let Err(e) = core
+        .port_mut()
+        .set_timeout(Duration::from_secs(timeouts::NORMAL_SECS))
+    {
+        eprintln!("Warning: couldn't restore timeout: {}", e);
+    }
+
+    println!("\nMonitor stopped.");
+
+    result
 }
 
 /// Handle audio capture and playback commands.

--- a/ctl/src/main.rs
+++ b/ctl/src/main.rs
@@ -842,7 +842,8 @@ fn monitor_handler(
     let reset = args.get_flag("reset");
 
     if let Err(e) = tokio::task::block_in_place(|| {
-        tokio::runtime::Handle::current().block_on(dispatch(Command::Monitor { target, reset }, core))
+        tokio::runtime::Handle::current()
+            .block_on(dispatch(Command::Monitor { target, reset }, core))
     }) {
         eprintln!("Error: {}", e);
     }

--- a/ctl/src/main.rs
+++ b/ctl/src/main.rs
@@ -86,6 +86,13 @@ enum Command {
         action: AudioAction,
     },
 
+    /// Monitor UI and NET logs together
+    Monitor {
+        /// Reset both chips before monitoring
+        #[arg(long)]
+        reset: bool,
+    },
+
     /// Exit the REPL
     Exit,
 }
@@ -721,6 +728,7 @@ async fn dispatch(cmd: Command, core: &mut Core) -> Result<(), Box<dyn std::erro
             Ok(())
         }
         Command::Audio { action } => handlers::handle_audio(action, core).await,
+        Command::Monitor { reset } => handlers::handle_monitor(reset, core).await,
         Command::Exit => {
             std::process::exit(0);
         }
@@ -827,6 +835,20 @@ fn audio_handler(
     Ok(None)
 }
 
+fn monitor_handler(
+    args: ArgMatches,
+    core: &mut Core,
+) -> Result<Option<String>, reedline_repl_rs::Error> {
+    let reset = args.get_flag("reset");
+
+    if let Err(e) = tokio::task::block_in_place(|| {
+        tokio::runtime::Handle::current().block_on(dispatch(Command::Monitor { reset }, core))
+    }) {
+        eprintln!("Error: {}", e);
+    }
+    Ok(None)
+}
+
 fn exit_handler(
     _args: ArgMatches,
     core: &mut Core,
@@ -850,6 +872,7 @@ fn run_repl(core: Core, port_name: &str) -> Result<(), reedline_repl_rs::Error> 
     callbacks.insert("hello".to_string(), hello_handler);
     callbacks.insert("circular-ping".to_string(), circular_ping_handler);
     callbacks.insert("audio".to_string(), audio_handler);
+    callbacks.insert("monitor".to_string(), monitor_handler);
     callbacks.insert("exit".to_string(), exit_handler);
 
     let mut repl = Repl::<Core, reedline_repl_rs::Error>::new(core)

--- a/ctl/src/main.rs
+++ b/ctl/src/main.rs
@@ -86,15 +86,25 @@ enum Command {
         action: AudioAction,
     },
 
-    /// Monitor UI and NET logs together
+    /// Monitor logs from UI, NET, or both
     Monitor {
-        /// Reset both chips before monitoring
+        #[arg(value_enum, default_value_t = MonitorTarget::Both)]
+        target: MonitorTarget,
+        /// Reset the selected chip or chips before monitoring
         #[arg(long)]
         reset: bool,
     },
 
     /// Exit the REPL
     Exit,
+}
+
+#[derive(Debug, Clone, Copy, Default, clap::ValueEnum)]
+enum MonitorTarget {
+    Ui,
+    Net,
+    #[default]
+    Both,
 }
 
 #[derive(Debug, Clone, Subcommand)]
@@ -195,13 +205,6 @@ enum UiAction {
     Reset {
         #[command(subcommand)]
         action: Option<ResetAction>,
-    },
-
-    /// Monitor log messages from UI chip
-    Monitor {
-        /// Reset the chip before monitoring
-        #[arg(long)]
-        reset: bool,
     },
 
     /// Stack usage measurement
@@ -492,13 +495,6 @@ enum NetAction {
     /// Erase the NET chip's flash
     Erase,
 
-    /// Monitor data from NET chip (prints FromNet TLVs)
-    Monitor {
-        /// Reset the chip before monitoring
-        #[arg(long)]
-        reset: bool,
-    },
-
     /// Logs enabled control
     Logs {
         #[command(subcommand)]
@@ -728,7 +724,7 @@ async fn dispatch(cmd: Command, core: &mut Core) -> Result<(), Box<dyn std::erro
             Ok(())
         }
         Command::Audio { action } => handlers::handle_audio(action, core).await,
-        Command::Monitor { reset } => handlers::handle_monitor(reset, core).await,
+        Command::Monitor { target, reset } => handlers::handle_monitor(target, reset, core).await,
         Command::Exit => {
             std::process::exit(0);
         }
@@ -839,10 +835,14 @@ fn monitor_handler(
     args: ArgMatches,
     core: &mut Core,
 ) -> Result<Option<String>, reedline_repl_rs::Error> {
+    let target = args
+        .get_one::<MonitorTarget>("target")
+        .copied()
+        .unwrap_or(MonitorTarget::Both);
     let reset = args.get_flag("reset");
 
     if let Err(e) = tokio::task::block_in_place(|| {
-        tokio::runtime::Handle::current().block_on(dispatch(Command::Monitor { reset }, core))
+        tokio::runtime::Handle::current().block_on(dispatch(Command::Monitor { target, reset }, core))
     }) {
         eprintln!("Error: {}", e);
     }

--- a/link/src/ctl/core.rs
+++ b/link/src/ctl/core.rs
@@ -62,6 +62,11 @@ pub enum CtlError {
     Timeout,
 }
 
+pub enum MonitorEvent {
+    UiLog(String),
+    NetData(Vec<u8>),
+}
+
 impl core::fmt::Display for CtlError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
@@ -1207,6 +1212,36 @@ impl<P: CtlPort> CtlCore<P> {
         // Return None to indicate we got data but not a complete Log TLV yet
         // (caller will call us again in the next iteration)
         Ok(None)
+    }
+
+    /// Try to read either a UI log line or raw NET data for monitor mode.
+    pub async fn try_read_monitor_event(&mut self) -> Result<Option<MonitorEvent>, CtlError> {
+        loop {
+            if let Some(tlv) = Self::try_parse_tlv_from_buffer::<UiToCtl>(&mut self.ui_buffer)? {
+                if tlv.tlv_type == UiToCtl::Log {
+                    let msg = match core::str::from_utf8(&tlv.value) {
+                        Ok(msg) => msg.into(),
+                        Err(_) => format!("<invalid utf8: {:?}>", tlv.value.as_slice()),
+                    };
+                    return Ok(Some(MonitorEvent::UiLog(msg)));
+                }
+                continue;
+            }
+
+            let Some(tlv) = self.read_tlv::<MgmtToCtl>().await? else {
+                return Ok(None);
+            };
+
+            match tlv.tlv_type {
+                MgmtToCtl::FromUi => {
+                    let _ = self.ui_buffer.extend_from_slice(&tlv.value);
+                }
+                MgmtToCtl::FromNet => {
+                    return Ok(Some(MonitorEvent::NetData(tlv.value.to_vec())));
+                }
+                _ => {}
+            }
+        }
     }
 
     /// Try to read any TLV from the UI chip (non-blocking/timeout-aware).

--- a/link/src/ctl/mod.rs
+++ b/link/src/ctl/mod.rs
@@ -12,7 +12,7 @@ pub mod core;
 pub mod port;
 
 // Re-export core types
-pub use self::core::{CtlCore, CtlError, escape_non_ascii};
+pub use self::core::{CtlCore, CtlError, MonitorEvent, escape_non_ascii};
 pub use self::port::CtlPort;
 
 #[cfg(feature = "std")]


### PR DESCRIPTION
Added an option to the base ctl that is just `monitor` where both ui and net logs are merged into one so that they can be observed at the same time.

Closes #14