### PR TITLE
Moq injection

### DIFF
--- a/ctl/src/handlers/net.rs
+++ b/ctl/src/handlers/net.rs
@@ -300,13 +300,20 @@ pub async fn handle_net(
         }
         NetAction::Blaster { action } => match action.unwrap_or_default() {
             NetBlasterAction::Get => {
-                let enabled = core.net_get_blaster().await?;
-                println!("{}", if enabled { "on" } else { "off" });
+                let (enabled, blaster_size) = core.net_get_blaster().await?;
+                println!("{} {}", if enabled { "on" } else { "off" }, blaster_size);
                 Ok(())
             }
-            NetBlasterAction::Set { state } => {
-                core.net_set_blaster(state.is_on()).await?;
-                println!("NET blaster: {}", if state.is_on() { "on" } else { "off" });
+            NetBlasterAction::Set {
+                state,
+                blaster_size,
+            } => {
+                core.net_set_blaster(state.is_on(), blaster_size).await?;
+                println!(
+                    "NET blaster: {} {}",
+                    if state.is_on() { "on" } else { "off" },
+                    blaster_size
+                );
                 Ok(())
             }
         },

--- a/ctl/src/handlers/net.rs
+++ b/ctl/src/handlers/net.rs
@@ -2,14 +2,25 @@
 
 use super::Core;
 use crate::{
-    GetSetString, LanguageAction, LogsAction, NetAction, NetLoopbackAction, PinAction, PinLevel,
-    ResetAction, WifiAction,
+    BlasterPattern, GetSetString, LanguageAction, LogsAction, NetAction, NetBlasterAction,
+    NetLoopbackAction, PinAction, PinLevel, ResetAction, WifiAction,
 };
 use indicatif::{ProgressBar, ProgressStyle};
 use link::ctl::ProgressCallbacks;
 use link::ctl::flash::StdDelay;
 use link::{NetLoopbackMode, Pin, PinValue};
+use rand::Rng;
 use std::io::Write;
+use std::time::Duration;
+
+fn blaster_payload(pattern: BlasterPattern, num_bytes: usize) -> Vec<u8> {
+    let mut payload = vec![0u8; num_bytes];
+    match pattern {
+        BlasterPattern::Random => rand::rng().fill(&mut payload[..]),
+        BlasterPattern::Fill => payload.fill(0x55),
+    }
+    payload
+}
 
 /// Progress handler for NET chip flashing that wraps an indicatif ProgressBar.
 struct FlashProgress {
@@ -81,6 +92,8 @@ pub async fn handle_net(
             | NetAction::Language { .. }
             | NetAction::Channel { .. }
             | NetAction::Ai { .. }
+            | NetAction::BlasterSend { .. }
+            | NetAction::Blaster { .. }
             | NetAction::ClearStorage
             | NetAction::BurnJtagEfuse { .. }
     );
@@ -262,6 +275,38 @@ pub async fn handle_net(
             NetLoopbackAction::Moq => {
                 core.net_set_loopback(NetLoopbackMode::Moq).await?;
                 println!("NET loopback: moq (hear own audio via relay)");
+                Ok(())
+            }
+        },
+        NetAction::BlasterSend {
+            pattern,
+            num_bytes,
+            num_repeat,
+            time_delay_ms,
+        } => {
+            let delay = Duration::from_millis(time_delay_ms);
+            for i in 0..num_repeat {
+                let payload = blaster_payload(pattern, num_bytes as usize);
+                core.net_blaster_send(&payload).await?;
+                if i + 1 < num_repeat {
+                    tokio::time::sleep(delay).await;
+                }
+            }
+            println!(
+                "NET blaster sent {} payload(s) of {} byte(s)",
+                num_repeat, num_bytes
+            );
+            Ok(())
+        }
+        NetAction::Blaster { action } => match action.unwrap_or_default() {
+            NetBlasterAction::Get => {
+                let enabled = core.net_get_blaster().await?;
+                println!("{}", if enabled { "on" } else { "off" });
+                Ok(())
+            }
+            NetBlasterAction::Set { state } => {
+                core.net_set_blaster(state.is_on()).await?;
+                println!("NET blaster: {}", if state.is_on() { "on" } else { "off" });
                 Ok(())
             }
         },

--- a/ctl/src/handlers/ui.rs
+++ b/ctl/src/handlers/ui.rs
@@ -13,8 +13,8 @@ use link::ctl::flash::FlashPhase;
 use link::ctl::{MonitorEvent, escape_non_ascii};
 use link::protocol_config::timeouts;
 use link::{
-    AdjDirection, AudioTransmitMode, CtlToMgmt, Pin, PinValue, UiAudioReceivedPath,
-    UiLoopbackMode, UiToCtl,
+    AdjDirection, AudioTransmitMode, CtlToMgmt, Pin, PinValue, UiAudioReceivedPath, UiLoopbackMode,
+    UiToCtl,
 };
 use std::io::Write;
 use std::sync::mpsc;

--- a/ctl/src/handlers/ui.rs
+++ b/ctl/src/handlers/ui.rs
@@ -2,7 +2,7 @@
 
 use super::Core;
 use crate::{
-    AudioAction, AudioReceivedPathAction, AudioTransmitModeAction, CaptureMode,
+    AudioAction, AudioReceivedPathAction, AudioTransmitModeAction, CaptureMode, CaptureReceiveMode,
     CaptureTransmitMode, GetSetHex, GetSetU32, LogsAction, LoopbackAction, MonitorTarget,
     PinAction, PinLevel, PlayMode, ResetAction, StackAction, UiAction, VolumeAction,
 };
@@ -13,7 +13,8 @@ use link::ctl::flash::FlashPhase;
 use link::ctl::{MonitorEvent, escape_non_ascii};
 use link::protocol_config::timeouts;
 use link::{
-    AdjDirection, AudioTransmitMode, PinValue, UiAudioReceivedPath, UiLoopbackMode, UiToCtl,
+    AdjDirection, AudioTransmitMode, CtlToMgmt, Pin, PinValue, UiAudioReceivedPath,
+    UiLoopbackMode, UiToCtl,
 };
 use std::io::Write;
 use std::sync::mpsc;
@@ -423,13 +424,13 @@ pub async fn handle_monitor(
         if matches!(target, MonitorTarget::Ui | MonitorTarget::Both) {
             println!("Resetting UI chip...");
             let delay = |ms| tokio::time::sleep(Duration::from_millis(ms));
-            core.reset_ui_to_user(delay).await?;
+            reset_ui_to_user_no_ack(core, delay).await?;
         }
 
         if matches!(target, MonitorTarget::Net | MonitorTarget::Both) {
             println!("Resetting NET chip...");
             let delay = |ms| tokio::time::sleep(Duration::from_millis(ms));
-            core.reset_net_to_user(delay).await?;
+            reset_net_to_user_no_ack(core, delay).await?;
         }
     }
 
@@ -476,7 +477,7 @@ pub async fn handle_monitor(
                         return Err(format!("Read error: {:?}", e).into());
                     }
                 },
-                MonitorTarget::Net => match core.read_tlv_raw().await {
+                MonitorTarget::Net => match core.read_tlv_raw_lossy().await {
                     Ok(Some(tlv)) => {
                         if tlv.tlv_type == link::MgmtToCtl::FromNet {
                             let text = escape_non_ascii(&tlv.value);
@@ -529,6 +530,51 @@ pub async fn handle_monitor(
     result
 }
 
+async fn set_pin_no_ack(
+    core: &mut Core,
+    pin: Pin,
+    value: PinValue,
+) -> Result<(), Box<dyn std::error::Error>> {
+    core.write_tlv_raw(CtlToMgmt::SetPin, &[pin as u8, value as u8])
+        .await?;
+    Ok(())
+}
+
+async fn reset_ui_to_user_no_ack<D, F>(
+    core: &mut Core,
+    delay_ms: D,
+) -> Result<(), Box<dyn std::error::Error>>
+where
+    D: Fn(u64) -> F,
+    F: core::future::Future<Output = ()>,
+{
+    use link::timing::reset::STM32_SIGNAL_TRANSITION_MS;
+
+    set_pin_no_ack(core, Pin::UiBoot0, PinValue::Low).await?;
+    set_pin_no_ack(core, Pin::UiBoot1, PinValue::High).await?;
+    set_pin_no_ack(core, Pin::UiRst, PinValue::Low).await?;
+    delay_ms(STM32_SIGNAL_TRANSITION_MS).await;
+    set_pin_no_ack(core, Pin::UiRst, PinValue::High).await?;
+    Ok(())
+}
+
+async fn reset_net_to_user_no_ack<D, F>(
+    core: &mut Core,
+    delay_ms: D,
+) -> Result<(), Box<dyn std::error::Error>>
+where
+    D: Fn(u64) -> F,
+    F: core::future::Future<Output = ()>,
+{
+    use link::timing::reset::ESP32_RESET_HOLD_MS;
+
+    set_pin_no_ack(core, Pin::NetBoot, PinValue::High).await?;
+    set_pin_no_ack(core, Pin::NetRst, PinValue::Low).await?;
+    delay_ms(ESP32_RESET_HOLD_MS).await;
+    set_pin_no_ack(core, Pin::NetRst, PinValue::High).await?;
+    Ok(())
+}
+
 /// Handle audio capture and playback commands.
 pub async fn handle_audio(
     action: AudioAction,
@@ -536,11 +582,15 @@ pub async fn handle_audio(
 ) -> Result<(), Box<dyn std::error::Error>> {
     match action {
         AudioAction::Capture { mode } => match mode {
-            CaptureMode::Live { transmit_mode } => capture_live(core, transmit_mode).await,
+            CaptureMode::Live {
+                transmit_mode,
+                receive_mode,
+            } => capture_live(core, transmit_mode, receive_mode).await,
             CaptureMode::Wav {
                 basename,
                 transmit_mode,
-            } => capture_wav(core, &basename, transmit_mode).await,
+                receive_mode,
+            } => capture_wav(core, &basename, transmit_mode, receive_mode).await,
         },
         AudioAction::Play { mode } => match mode {
             PlayMode::Wav { file } => play_wav(core, &file).await,
@@ -552,8 +602,57 @@ pub async fn handle_audio(
 fn ui_transmit_mode(mode: CaptureTransmitMode) -> AudioTransmitMode {
     match mode {
         CaptureTransmitMode::Ctl => AudioTransmitMode::Ctl,
+        CaptureTransmitMode::Net => AudioTransmitMode::Net,
         CaptureTransmitMode::Both => AudioTransmitMode::Both,
     }
+}
+
+fn ui_receive_mode(mode: CaptureReceiveMode) -> UiAudioReceivedPath {
+    match mode {
+        CaptureReceiveMode::Ctl => UiAudioReceivedPath::Ctl,
+        CaptureReceiveMode::Headphones => UiAudioReceivedPath::Headphones,
+        CaptureReceiveMode::Both => UiAudioReceivedPath::Both,
+    }
+}
+
+async fn setup_capture_routing(
+    core: &mut Core,
+    transmit_mode: CaptureTransmitMode,
+    receive_mode: CaptureReceiveMode,
+) -> Result<(AudioTransmitMode, UiAudioReceivedPath), Box<dyn std::error::Error>> {
+    let previous_transmit_mode = core.ui_get_audio_transmit_mode().await?;
+    let previous_receive_mode = core.ui_get_audio_received_path().await?;
+
+    let transmit_mode = ui_transmit_mode(transmit_mode);
+    let receive_mode = ui_receive_mode(receive_mode);
+
+    println!("Setting audio transmit mode to {}...", transmit_mode);
+    core.ui_set_audio_transmit_mode(transmit_mode).await?;
+    println!("Setting audio receive mode to {}...", receive_mode);
+    core.ui_set_audio_received_path(receive_mode).await?;
+
+    Ok((previous_transmit_mode, previous_receive_mode))
+}
+
+async fn restore_capture_routing(
+    core: &mut Core,
+    previous_transmit_mode: AudioTransmitMode,
+    previous_receive_mode: UiAudioReceivedPath,
+) -> Result<(), Box<dyn std::error::Error>> {
+    println!(
+        "\nRestoring audio transmit mode to {}...",
+        previous_transmit_mode
+    );
+    core.ui_set_audio_transmit_mode(previous_transmit_mode)
+        .await?;
+    println!(
+        "Restoring audio receive mode to {}...",
+        previous_receive_mode
+    );
+    core.ui_set_audio_received_path(previous_receive_mode)
+        .await?;
+
+    Ok(())
 }
 
 /// AudioSink that sends samples to a cpal output stream via channel.
@@ -571,6 +670,7 @@ impl AudioSink for CpalSink {
 async fn capture_live(
     core: &mut Core,
     transmit_mode: CaptureTransmitMode,
+    receive_mode: CaptureReceiveMode,
 ) -> Result<(), Box<dyn std::error::Error>> {
     use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
     use rubato::{FftFixedIn, Resampler};
@@ -584,9 +684,8 @@ async fn capture_live(
     let sframe_key = core.get_sframe_key().await?;
     println!("SFrame key: {}", hex::encode(&sframe_key));
 
-    let transmit_mode = ui_transmit_mode(transmit_mode);
-    println!("Setting audio transmit mode to {}...", transmit_mode);
-    core.ui_set_audio_transmit_mode(transmit_mode).await?;
+    let (previous_transmit_mode, previous_receive_mode) =
+        setup_capture_routing(core, transmit_mode, receive_mode).await?;
 
     // Create capture session
     let mut session = CaptureSession::new(&sframe_key);
@@ -858,10 +957,7 @@ async fn capture_live(
     terminal::disable_raw_mode()?;
     drop(stream);
 
-    // Restore audio transmit mode to NET
-    println!("\nRestoring audio transmit mode to NET...");
-    core.ui_set_audio_transmit_mode(AudioTransmitMode::Net)
-        .await?;
+    restore_capture_routing(core, previous_transmit_mode, previous_receive_mode).await?;
 
     // Restore timeout
     if let Err(e) = core
@@ -917,6 +1013,7 @@ async fn capture_wav(
     core: &mut Core,
     basename: &str,
     transmit_mode: CaptureTransmitMode,
+    receive_mode: CaptureReceiveMode,
 ) -> Result<(), Box<dyn std::error::Error>> {
     // Ping the ui until it responds or times out.
     core.ping_ui_until_pong().await?;
@@ -926,9 +1023,8 @@ async fn capture_wav(
     let sframe_key = core.get_sframe_key().await?;
     println!("SFrame key: {}", hex::encode(&sframe_key));
 
-    let transmit_mode = ui_transmit_mode(transmit_mode);
-    println!("Setting audio transmit mode to {}...", transmit_mode);
-    core.ui_set_audio_transmit_mode(transmit_mode).await?;
+    let (previous_transmit_mode, previous_receive_mode) =
+        setup_capture_routing(core, transmit_mode, receive_mode).await?;
 
     // Create capture session
     let mut session = CaptureSession::new(&sframe_key);
@@ -1099,10 +1195,7 @@ async fn capture_wav(
     // Cleanup
     terminal::disable_raw_mode()?;
 
-    // Restore audio transmit mode to NET
-    println!("\nRestoring audio transmit mode to NET...");
-    core.ui_set_audio_transmit_mode(AudioTransmitMode::Net)
-        .await?;
+    restore_capture_routing(core, previous_transmit_mode, previous_receive_mode).await?;
 
     // Restore timeout
     if let Err(e) = core

--- a/ctl/src/handlers/ui.rs
+++ b/ctl/src/handlers/ui.rs
@@ -2,8 +2,9 @@
 
 use super::Core;
 use crate::{
-    AudioAction, AudioModeAction, CaptureMode, GetSetHex, GetSetU32, LogsAction, LoopbackAction,
-    MonitorTarget, PinAction, PinLevel, PlayMode, ResetAction, StackAction, UiAction, VolumeAction,
+    AudioAction, AudioReceivedPathAction, AudioTransmitModeAction, CaptureMode,
+    CaptureTransmitMode, GetSetHex, GetSetU32, LogsAction, LoopbackAction, MonitorTarget,
+    PinAction, PinLevel, PlayMode, ResetAction, StackAction, UiAction, VolumeAction,
 };
 use indicatif::{ProgressBar, ProgressStyle};
 use link::ctl::SetTimeout;
@@ -11,7 +12,9 @@ use link::ctl::audio_capture::{AudioSink, CaptureSession, PlaybackSession};
 use link::ctl::flash::FlashPhase;
 use link::ctl::{MonitorEvent, escape_non_ascii};
 use link::protocol_config::timeouts;
-use link::{AdjDirection, AudioMode, PinValue, UiLoopbackMode, UiToCtl};
+use link::{
+    AdjDirection, AudioTransmitMode, PinValue, UiAudioReceivedPath, UiLoopbackMode, UiToCtl,
+};
 use std::io::Write;
 use std::sync::mpsc;
 use std::time::Duration;
@@ -358,20 +361,53 @@ pub async fn handle_ui(
                 Ok(())
             }
         },
-        UiAction::AudioMode { action } => match action.unwrap_or_default() {
-            AudioModeAction::Get => {
-                let mode = core.ui_get_audio_mode().await?;
+        UiAction::AudioTransmitMode { action } => match action.unwrap_or_default() {
+            AudioTransmitModeAction::Get => {
+                let mode = core.ui_get_audio_transmit_mode().await?;
                 println!("{}", mode);
                 Ok(())
             }
-            AudioModeAction::Ctl => {
-                core.ui_set_audio_mode(AudioMode::Ctl).await?;
-                println!("Audio mode: ctl");
+            AudioTransmitModeAction::Ctl => {
+                core.ui_set_audio_transmit_mode(AudioTransmitMode::Ctl)
+                    .await?;
+                println!("Audio transmit mode: ctl");
                 Ok(())
             }
-            AudioModeAction::Net => {
-                core.ui_set_audio_mode(AudioMode::Net).await?;
-                println!("Audio mode: net");
+            AudioTransmitModeAction::Net => {
+                core.ui_set_audio_transmit_mode(AudioTransmitMode::Net)
+                    .await?;
+                println!("Audio transmit mode: net");
+                Ok(())
+            }
+        },
+        UiAction::AudioReceivedPath { action } => match action.unwrap_or_default() {
+            AudioReceivedPathAction::Get => {
+                let path = core.ui_get_audio_received_path().await?;
+                println!("{}", path);
+                Ok(())
+            }
+            AudioReceivedPathAction::None => {
+                core.ui_set_audio_received_path(UiAudioReceivedPath::None)
+                    .await?;
+                println!("Audio received path: none");
+                Ok(())
+            }
+            AudioReceivedPathAction::Headphones => {
+                core.ui_set_audio_received_path(UiAudioReceivedPath::Headphones)
+                    .await?;
+                println!("Audio received path: headphones");
+                Ok(())
+            }
+            AudioReceivedPathAction::Ctl => {
+                core.ui_set_audio_received_path(UiAudioReceivedPath::Ctl)
+                    .await?;
+                println!("Audio received path: ctl");
+                Ok(())
+            }
+            AudioReceivedPathAction::Both => {
+                core.ui_set_audio_received_path(UiAudioReceivedPath::Both)
+                    .await?;
+                println!("Audio received path: both");
                 Ok(())
             }
         },
@@ -500,13 +536,23 @@ pub async fn handle_audio(
 ) -> Result<(), Box<dyn std::error::Error>> {
     match action {
         AudioAction::Capture { mode } => match mode {
-            CaptureMode::Live => capture_live(core).await,
-            CaptureMode::Wav { basename } => capture_wav(core, &basename).await,
+            CaptureMode::Live { transmit_mode } => capture_live(core, transmit_mode).await,
+            CaptureMode::Wav {
+                basename,
+                transmit_mode,
+            } => capture_wav(core, &basename, transmit_mode).await,
         },
         AudioAction::Play { mode } => match mode {
             PlayMode::Wav { file } => play_wav(core, &file).await,
             PlayMode::Live => play_live(core).await,
         },
+    }
+}
+
+fn ui_transmit_mode(mode: CaptureTransmitMode) -> AudioTransmitMode {
+    match mode {
+        CaptureTransmitMode::Ctl => AudioTransmitMode::Ctl,
+        CaptureTransmitMode::Both => AudioTransmitMode::Both,
     }
 }
 
@@ -522,7 +568,10 @@ impl AudioSink for CpalSink {
 }
 
 /// Capture audio from the UI chip and play it through the computer speakers.
-async fn capture_live(core: &mut Core) -> Result<(), Box<dyn std::error::Error>> {
+async fn capture_live(
+    core: &mut Core,
+    transmit_mode: CaptureTransmitMode,
+) -> Result<(), Box<dyn std::error::Error>> {
     use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
     use rubato::{FftFixedIn, Resampler};
     use std::sync::{Arc, Mutex};
@@ -535,9 +584,9 @@ async fn capture_live(core: &mut Core) -> Result<(), Box<dyn std::error::Error>>
     let sframe_key = core.get_sframe_key().await?;
     println!("SFrame key: {}", hex::encode(&sframe_key));
 
-    // Set audio mode to CTL
-    println!("Setting audio mode to CTL...");
-    core.ui_set_audio_mode(AudioMode::Ctl).await?;
+    let transmit_mode = ui_transmit_mode(transmit_mode);
+    println!("Setting audio transmit mode to {}...", transmit_mode);
+    core.ui_set_audio_transmit_mode(transmit_mode).await?;
 
     // Create capture session
     let mut session = CaptureSession::new(&sframe_key);
@@ -763,6 +812,22 @@ async fn capture_live(core: &mut Core) -> Result<(), Box<dyn std::error::Error>>
                                 }
                             }
                         }
+                        UiToCtl::AudioFrameUnprotected => {
+                            if capturing {
+                                match session.process_unprotected_frame(&tlv.value, &mut sink) {
+                                    Ok(true) => {
+                                        frame_count += 1;
+                                        print!("\r[CAPTURING] {} frames", frame_count);
+                                        std::io::stdout().flush().ok();
+                                    }
+                                    Ok(false) => {}
+                                    Err(e) => {
+                                        print!("\r[ERROR] {}\r\n", e);
+                                        std::io::stdout().flush().ok();
+                                    }
+                                }
+                            }
+                        }
                         UiToCtl::Log => {
                             // Print log messages
                             if let Ok(msg) = core::str::from_utf8(&tlv.value) {
@@ -793,9 +858,10 @@ async fn capture_live(core: &mut Core) -> Result<(), Box<dyn std::error::Error>>
     terminal::disable_raw_mode()?;
     drop(stream);
 
-    // Restore audio mode to NET
-    println!("\nRestoring audio mode to NET...");
-    core.ui_set_audio_mode(AudioMode::Net).await?;
+    // Restore audio transmit mode to NET
+    println!("\nRestoring audio transmit mode to NET...");
+    core.ui_set_audio_transmit_mode(AudioTransmitMode::Net)
+        .await?;
 
     // Restore timeout
     if let Err(e) = core
@@ -847,7 +913,11 @@ fn save_wav_file(
 
 /// Capture audio from the UI chip and save to numbered WAV files.
 /// Each PTT press creates a new file: basename_001.wav, basename_002.wav, etc.
-async fn capture_wav(core: &mut Core, basename: &str) -> Result<(), Box<dyn std::error::Error>> {
+async fn capture_wav(
+    core: &mut Core,
+    basename: &str,
+    transmit_mode: CaptureTransmitMode,
+) -> Result<(), Box<dyn std::error::Error>> {
     // Ping the ui until it responds or times out.
     core.ping_ui_until_pong().await?;
 
@@ -856,9 +926,9 @@ async fn capture_wav(core: &mut Core, basename: &str) -> Result<(), Box<dyn std:
     let sframe_key = core.get_sframe_key().await?;
     println!("SFrame key: {}", hex::encode(&sframe_key));
 
-    // Set audio mode to CTL
-    println!("Setting audio mode to CTL...");
-    core.ui_set_audio_mode(AudioMode::Ctl).await?;
+    let transmit_mode = ui_transmit_mode(transmit_mode);
+    println!("Setting audio transmit mode to {}...", transmit_mode);
+    core.ui_set_audio_transmit_mode(transmit_mode).await?;
 
     // Create capture session
     let mut session = CaptureSession::new(&sframe_key);
@@ -973,6 +1043,33 @@ async fn capture_wav(core: &mut Core, basename: &str) -> Result<(), Box<dyn std:
                                 }
                             }
                         }
+                        UiToCtl::AudioFrameUnprotected => {
+                            if capturing {
+                                match session.process_unprotected_frame(&tlv.value, &mut sink) {
+                                    Ok(true) => {
+                                        frame_count += 1;
+                                        print!(
+                                            "\r[RECORDING #{}] {} frames, {} samples",
+                                            file_number,
+                                            frame_count,
+                                            sink.samples.len()
+                                        );
+                                        std::io::stdout().flush().ok();
+                                    }
+                                    Ok(false) => {
+                                        print!(
+                                            "\r[SKIP] invalid frame ({} bytes)\r\n",
+                                            tlv.value.len()
+                                        );
+                                        std::io::stdout().flush().ok();
+                                    }
+                                    Err(e) => {
+                                        print!("\r[ERROR] {}\r\n", e);
+                                        std::io::stdout().flush().ok();
+                                    }
+                                }
+                            }
+                        }
                         UiToCtl::Log => {
                             // Print log messages
                             if let Ok(msg) = core::str::from_utf8(&tlv.value) {
@@ -1002,9 +1099,10 @@ async fn capture_wav(core: &mut Core, basename: &str) -> Result<(), Box<dyn std:
     // Cleanup
     terminal::disable_raw_mode()?;
 
-    // Restore audio mode to NET
-    println!("\nRestoring audio mode to NET...");
-    core.ui_set_audio_mode(AudioMode::Net).await?;
+    // Restore audio transmit mode to NET
+    println!("\nRestoring audio transmit mode to NET...");
+    core.ui_set_audio_transmit_mode(AudioTransmitMode::Net)
+        .await?;
 
     // Restore timeout
     if let Err(e) = core
@@ -1068,9 +1166,10 @@ async fn play_wav(
     let sframe_key = core.get_sframe_key().await?;
     println!("SFrame key: {}", hex::encode(&sframe_key));
 
-    // Set audio mode to CTL
-    println!("Setting audio mode to CTL...");
-    core.ui_set_audio_mode(AudioMode::Ctl).await?;
+    // Set audio transmit mode to CTL
+    println!("Setting audio transmit mode to CTL...");
+    core.ui_set_audio_transmit_mode(AudioTransmitMode::Ctl)
+        .await?;
 
     // Create playback session
     let mut session = PlaybackSession::new(&sframe_key);
@@ -1105,8 +1204,9 @@ async fn play_wav(
     // Send audio end
     core.ui_send_audio_end().await?;
 
-    println!("\n\nRestoring audio mode to NET...");
-    core.ui_set_audio_mode(AudioMode::Net).await?;
+    println!("\n\nRestoring audio transmit mode to NET...");
+    core.ui_set_audio_transmit_mode(AudioTransmitMode::Net)
+        .await?;
 
     println!("Playback complete.");
     Ok(())
@@ -1127,9 +1227,10 @@ async fn play_live(core: &mut Core) -> Result<(), Box<dyn std::error::Error>> {
     let sframe_key = core.get_sframe_key().await?;
     println!("SFrame key: {}", hex::encode(&sframe_key));
 
-    // Set audio mode to CTL
-    println!("Setting audio mode to CTL...");
-    core.ui_set_audio_mode(AudioMode::Ctl).await?;
+    // Set audio transmit mode to CTL
+    println!("Setting audio transmit mode to CTL...");
+    core.ui_set_audio_transmit_mode(AudioTransmitMode::Ctl)
+        .await?;
 
     // Create playback session
     let mut session = PlaybackSession::new(&sframe_key);
@@ -1309,9 +1410,10 @@ async fn play_live(core: &mut Core) -> Result<(), Box<dyn std::error::Error>> {
         core.ui_send_audio_end().await?;
     }
 
-    // Restore audio mode to NET
-    println!("\n\nRestoring audio mode to NET...");
-    core.ui_set_audio_mode(AudioMode::Net).await?;
+    // Restore audio transmit mode to NET
+    println!("\n\nRestoring audio transmit mode to NET...");
+    core.ui_set_audio_transmit_mode(AudioTransmitMode::Net)
+        .await?;
 
     println!("Streaming stopped. {} frames sent.", frame_count);
 

--- a/ctl/src/handlers/ui.rs
+++ b/ctl/src/handlers/ui.rs
@@ -2,9 +2,9 @@
 
 use super::Core;
 use crate::{
-    AudioAction, AudioReceivedPathAction, AudioTransmitModeAction, CaptureMode, CaptureReceiveMode,
-    CaptureTransmitMode, GetSetHex, GetSetU32, LogsAction, LoopbackAction, MonitorTarget,
-    PinAction, PinLevel, PlayMode, ResetAction, StackAction, UiAction, VolumeAction,
+    AudioAction, AudioReceivedPathAction, AudioTransmitModeAction, BlasterPattern, CaptureMode,
+    CaptureReceiveMode, CaptureTransmitMode, GetSetHex, GetSetU32, LogsAction, LoopbackAction,
+    MonitorTarget, PinAction, PinLevel, PlayMode, ResetAction, StackAction, UiAction, VolumeAction,
 };
 use indicatif::{ProgressBar, ProgressStyle};
 use link::ctl::SetTimeout;
@@ -16,9 +16,19 @@ use link::{
     AdjDirection, AudioTransmitMode, CtlToMgmt, Pin, PinValue, UiAudioReceivedPath, UiLoopbackMode,
     UiToCtl,
 };
+use rand::Rng;
 use std::io::Write;
 use std::sync::mpsc;
 use std::time::Duration;
+
+fn blaster_payload(pattern: BlasterPattern, num_bytes: usize) -> Vec<u8> {
+    let mut payload = vec![0u8; num_bytes];
+    match pattern {
+        BlasterPattern::Random => rand::rng().fill(&mut payload[..]),
+        BlasterPattern::Fill => payload.fill(0x55),
+    }
+    payload
+}
 
 pub async fn handle_ui(
     action: UiAction,
@@ -207,6 +217,26 @@ pub async fn handle_ui(
                 Ok(())
             }
         },
+        UiAction::BlasterSend {
+            pattern,
+            num_bytes,
+            num_repeat,
+            time_delay_ms,
+        } => {
+            let delay = Duration::from_millis(time_delay_ms);
+            for i in 0..num_repeat {
+                let payload = blaster_payload(pattern, num_bytes as usize);
+                core.ui_blaster_send(&payload).await?;
+                if i + 1 < num_repeat {
+                    tokio::time::sleep(delay).await;
+                }
+            }
+            println!(
+                "UI blaster sent {} payload(s) of {} byte(s)",
+                num_repeat, num_bytes
+            );
+            Ok(())
+        }
         UiAction::Boot0 {
             action: PinAction::Set { level },
         } => {

--- a/ctl/src/main.rs
+++ b/ctl/src/main.rs
@@ -223,11 +223,18 @@ enum UiAction {
     #[command(name = "clear-storage")]
     ClearStorage,
 
-    /// Get or set the audio routing mode (ctl or net)
-    #[command(name = "audio-mode")]
-    AudioMode {
+    /// Get or set the audio transmit mode (ctl or net)
+    #[command(name = "audio-transmit-mode")]
+    AudioTransmitMode {
         #[command(subcommand)]
-        action: Option<AudioModeAction>,
+        action: Option<AudioTransmitModeAction>,
+    },
+
+    /// Get or set where NET-received audio is routed
+    #[command(name = "audio-received-path")]
+    AudioReceivedPath {
+        #[command(subcommand)]
+        action: Option<AudioReceivedPathAction>,
     },
 }
 
@@ -393,14 +400,36 @@ enum LoopbackAction {
 }
 
 #[derive(Debug, Clone, Default, Subcommand)]
-enum AudioModeAction {
-    /// Get the current audio routing mode
+enum AudioTransmitModeAction {
+    /// Get the current audio transmit mode
     #[default]
     Get,
     /// Route audio to/from CTL for capture/playback testing
     Ctl,
     /// Route audio to/from NET (normal operation)
     Net,
+}
+
+#[derive(Debug, Clone, Copy, Default, clap::ValueEnum)]
+enum CaptureTransmitMode {
+    #[default]
+    Ctl,
+    Both,
+}
+
+#[derive(Debug, Clone, Default, Subcommand)]
+enum AudioReceivedPathAction {
+    /// Get the current received audio path
+    #[default]
+    Get,
+    /// Drop received audio
+    None,
+    /// Play received audio through headphones
+    Headphones,
+    /// Forward received audio to CTL
+    Ctl,
+    /// Forward received audio to CTL and play it locally
+    Both,
 }
 
 #[derive(Debug, Clone, Subcommand)]
@@ -420,10 +449,17 @@ enum AudioAction {
 #[derive(Debug, Clone, Subcommand)]
 enum CaptureMode {
     /// Play captured audio to computer speakers (8kHz mono)
-    Live,
+    Live {
+        #[arg(long, value_enum, default_value_t)]
+        transmit_mode: CaptureTransmitMode,
+    },
     /// Save captured audio to WAV files (8kHz mono 16-bit)
     /// Each PTT press creates a new file: basename_001.wav, basename_002.wav, etc.
-    Wav { basename: String },
+    Wav {
+        basename: String,
+        #[arg(long, value_enum, default_value_t)]
+        transmit_mode: CaptureTransmitMode,
+    },
 }
 
 #[derive(Debug, Clone, Subcommand)]

--- a/ctl/src/main.rs
+++ b/ctl/src/main.rs
@@ -414,6 +414,15 @@ enum AudioTransmitModeAction {
 enum CaptureTransmitMode {
     #[default]
     Ctl,
+    Net,
+    Both,
+}
+
+#[derive(Debug, Clone, Copy, Default, clap::ValueEnum)]
+enum CaptureReceiveMode {
+    Ctl,
+    #[default]
+    Headphones,
     Both,
 }
 
@@ -452,13 +461,17 @@ enum CaptureMode {
     Live {
         #[arg(long, value_enum, default_value_t)]
         transmit_mode: CaptureTransmitMode,
+        #[arg(long, value_enum, default_value_t)]
+        receive_mode: CaptureReceiveMode,
     },
     /// Save captured audio to WAV files (8kHz mono 16-bit)
     /// Each PTT press creates a new file: basename_001.wav, basename_002.wav, etc.
     Wav {
-        basename: String,
         #[arg(long, value_enum, default_value_t)]
         transmit_mode: CaptureTransmitMode,
+        #[arg(long, value_enum, default_value_t)]
+        receive_mode: CaptureReceiveMode,
+        basename: String,
     },
 }
 

--- a/ctl/src/main.rs
+++ b/ctl/src/main.rs
@@ -236,6 +236,37 @@ enum UiAction {
         #[command(subcommand)]
         action: Option<AudioReceivedPathAction>,
     },
+
+    /// Blast test payloads at the UI chip
+    #[command(name = "blaster-send")]
+    BlasterSend {
+        #[arg(value_enum)]
+        pattern: BlasterPattern,
+        #[arg(default_value_t = 1, value_parser = clap::value_parser!(u16).range(1..=640))]
+        num_bytes: u16,
+        #[arg(default_value_t = 1)]
+        num_repeat: u32,
+        #[arg(default_value_t = 20)]
+        time_delay_ms: u64,
+    },
+}
+
+#[derive(Debug, Clone, Copy, clap::ValueEnum)]
+enum BlasterPattern {
+    Random,
+    Fill,
+}
+
+#[derive(Debug, Clone, Copy, clap::ValueEnum)]
+enum OnOff {
+    On,
+    Off,
+}
+
+impl OnOff {
+    fn is_on(self) -> bool {
+        matches!(self, Self::On)
+    }
 }
 
 #[derive(Debug, Clone, Default, Subcommand)]
@@ -569,6 +600,25 @@ enum NetAction {
         action: Option<GetSetString>,
     },
 
+    /// Blast test payloads at the NET chip
+    #[command(name = "blaster-send")]
+    BlasterSend {
+        #[arg(value_enum)]
+        pattern: BlasterPattern,
+        #[arg(default_value_t = 1, value_parser = clap::value_parser!(u16).range(1..=640))]
+        num_bytes: u16,
+        #[arg(default_value_t = 1)]
+        num_repeat: u32,
+        #[arg(default_value_t = 20)]
+        time_delay_ms: u64,
+    },
+
+    /// Get or set NET blaster mode
+    Blaster {
+        #[command(subcommand)]
+        action: Option<NetBlasterAction>,
+    },
+
     /// Clear all stored configuration (NVS)
     #[command(name = "clear-storage")]
     ClearStorage,
@@ -588,6 +638,18 @@ enum WifiAction {
     Add { ssid: String, password: String },
     /// Clear all saved Wi-Fi credentials
     Clear,
+}
+
+#[derive(Debug, Clone, Default, Subcommand)]
+enum NetBlasterAction {
+    /// Get the current blaster state
+    #[default]
+    Get,
+    /// Set the blaster state
+    Set {
+        #[arg(value_enum)]
+        state: OnOff,
+    },
 }
 
 /// Open a serial port with standard settings using tokio-serial.

--- a/ctl/src/main.rs
+++ b/ctl/src/main.rs
@@ -649,6 +649,8 @@ enum NetBlasterAction {
     Set {
         #[arg(value_enum)]
         state: OnOff,
+        #[arg(default_value_t = -1, allow_hyphen_values = true)]
+        blaster_size: i16,
     },
 }
 

--- a/link/src/ctl/audio_capture.rs
+++ b/link/src/ctl/audio_capture.rs
@@ -1,7 +1,7 @@
 //! Audio capture from UI chip.
 //!
 //! This module handles receiving audio frames from the UI chip,
-//! decrypting them with SFrame, decoding A-law, and outputting PCM samples.
+//! optionally decrypting them with SFrame, decoding A-law, and outputting PCM samples.
 
 use crate::shared::chunk;
 use crate::shared::sframe::{self, SFrameState};
@@ -34,7 +34,7 @@ impl CaptureSession {
         }
     }
 
-    /// Process an incoming audio frame from the UI chip.
+    /// Process an incoming protected audio frame from the UI chip.
     ///
     /// The frame format is: channel_id (1 byte) + encrypted chunk
     /// (SFrame header + encrypted data + auth tag).
@@ -73,11 +73,43 @@ impl CaptureSession {
             return Err(CaptureError::DecryptionFailedDetail(e, header_info));
         }
 
-        // Parse the chunk to extract audio data
-        let parsed = chunk::parse_chunk(&heapless_buf).ok_or(CaptureError::InvalidChunk)?;
+        self.process_decrypted_chunk(&heapless_buf, sink)
+    }
 
-        let alaw_data =
-            &heapless_buf[parsed.audio_offset..parsed.audio_offset + parsed.audio_length];
+    /// Process an incoming audio frame that has already been SFrame-decrypted.
+    ///
+    /// The frame format is: channel_id (1 byte) + media chunk.
+    pub fn process_unprotected_frame<S: AudioSink>(
+        &mut self,
+        frame_data: &[u8],
+        sink: &mut S,
+    ) -> Result<bool, CaptureError> {
+        // Frame format: channel_id (1 byte) + decrypted chunk
+        if frame_data.len() < 2 {
+            return Ok(false);
+        }
+
+        // Extract channel_id (unused for now, but could be used for routing)
+        let _channel_id = frame_data[0];
+        let chunk_data = &frame_data[1..];
+
+        let mut heapless_buf: heapless::Vec<u8, 256> = heapless::Vec::new();
+        heapless_buf
+            .extend_from_slice(chunk_data)
+            .map_err(|_| CaptureError::BufferTooSmall)?;
+
+        self.process_decrypted_chunk(&heapless_buf, sink)
+    }
+
+    fn process_decrypted_chunk<S: AudioSink>(
+        &self,
+        chunk_data: &[u8],
+        sink: &mut S,
+    ) -> Result<bool, CaptureError> {
+        // Parse the chunk to extract audio data
+        let parsed = chunk::parse_chunk(chunk_data).ok_or(CaptureError::InvalidChunk)?;
+
+        let alaw_data = &chunk_data[parsed.audio_offset..parsed.audio_offset + parsed.audio_length];
 
         // Decode A-law to PCM
         let mut pcm_samples = Vec::with_capacity(alaw_data.len());
@@ -242,6 +274,19 @@ mod tests {
         frame
     }
 
+    /// Helper to create a test frame that is already decrypted.
+    fn create_test_unprotected_frame(pcm_samples: &[i16], channel_id: u8) -> Vec<u8> {
+        let alaw_data: Vec<u8> = pcm_samples.iter().map(|&s| encode_alaw(s)).collect();
+
+        let mut chunk_buf: heapless::Vec<u8, 256> = heapless::Vec::new();
+        chunk_buf.extend_from_slice(&alaw_data).unwrap();
+        chunk::prepend_media_header(&mut chunk_buf, false).unwrap();
+
+        let mut frame = vec![channel_id];
+        frame.extend_from_slice(&chunk_buf);
+        frame
+    }
+
     #[test]
     fn test_capture_session_roundtrip() {
         let key = [0xAA; 16];
@@ -308,6 +353,44 @@ mod tests {
         assert!(matches!(
             result,
             Err(CaptureError::DecryptionFailedDetail(_, Some((0, 0))))
+        ));
+    }
+
+    #[test]
+    fn test_capture_session_unprotected_roundtrip() {
+        let key = [0xAA; 16];
+        let mut session = CaptureSession::new(&key);
+        let mut sink = MockSink::new();
+
+        let test_pcm: Vec<i16> = vec![1000, 2000, 3000, -1000, -2000, -3000];
+        let frame = create_test_unprotected_frame(&test_pcm, 0);
+
+        let result = session.process_unprotected_frame(&frame, &mut sink);
+        assert!(result.is_ok());
+        assert!(result.unwrap());
+        assert_eq!(sink.samples.len(), test_pcm.len());
+
+        for (i, (&expected, &actual)) in test_pcm.iter().zip(sink.samples.iter()).enumerate() {
+            let expected_decoded = decode_alaw(encode_alaw(expected));
+            assert_eq!(
+                actual, expected_decoded,
+                "Sample {} mismatch: expected {} (from {}), got {}",
+                i, expected_decoded, expected, actual
+            );
+        }
+    }
+
+    #[test]
+    fn test_capture_session_unprotected_invalid_frame() {
+        let key = [0xBB; 16];
+        let mut session = CaptureSession::new(&key);
+        let mut sink = MockSink::new();
+
+        assert_eq!(session.process_unprotected_frame(&[], &mut sink), Ok(false));
+        assert_eq!(session.process_unprotected_frame(&[0x00], &mut sink), Ok(false));
+        assert!(matches!(
+            session.process_unprotected_frame(&[0x00, 0x01], &mut sink),
+            Err(CaptureError::InvalidChunk)
         ));
     }
 }

--- a/link/src/ctl/audio_capture.rs
+++ b/link/src/ctl/audio_capture.rs
@@ -387,7 +387,10 @@ mod tests {
         let mut sink = MockSink::new();
 
         assert_eq!(session.process_unprotected_frame(&[], &mut sink), Ok(false));
-        assert_eq!(session.process_unprotected_frame(&[0x00], &mut sink), Ok(false));
+        assert_eq!(
+            session.process_unprotected_frame(&[0x00], &mut sink),
+            Ok(false)
+        );
         assert!(matches!(
             session.process_unprotected_frame(&[0x00, 0x01], &mut sink),
             Err(CaptureError::InvalidChunk)

--- a/link/src/ctl/core.rs
+++ b/link/src/ctl/core.rs
@@ -1004,7 +1004,8 @@ impl<P: CtlPort> CtlCore<P> {
     pub async fn ui_get_audio_transmit_mode(
         &mut self,
     ) -> Result<crate::shared::AudioTransmitMode, CtlError> {
-        self.write_tlv_ui(CtlToUi::GetAudioTransmitMode, &[]).await?;
+        self.write_tlv_ui(CtlToUi::GetAudioTransmitMode, &[])
+            .await?;
         let tlv = self.read_tlv_ui_skip_log().await?;
         if tlv.tlv_type != UiToCtl::AudioTransmitMode {
             return Err(CtlError::UnexpectedResponse {
@@ -1045,7 +1046,8 @@ impl<P: CtlPort> CtlCore<P> {
 
     /// Get UI chip received audio output path.
     pub async fn ui_get_audio_received_path(&mut self) -> Result<UiAudioReceivedPath, CtlError> {
-        self.write_tlv_ui(CtlToUi::GetAudioReceivedPath, &[]).await?;
+        self.write_tlv_ui(CtlToUi::GetAudioReceivedPath, &[])
+            .await?;
         let tlv = self.read_tlv_ui_skip_log().await?;
         if tlv.tlv_type != UiToCtl::AudioReceivedPath {
             return Err(CtlError::UnexpectedResponse {

--- a/link/src/ctl/core.rs
+++ b/link/src/ctl/core.rs
@@ -217,6 +217,30 @@ impl<P: CtlPort> CtlCore<P> {
         }
     }
 
+    /// Read a TLV from the MGMT stream while tolerating malformed packets.
+    ///
+    /// Invalid TLV types and oversized packets are skipped byte-by-byte until a
+    /// valid sync word and packet are found.
+    async fn read_tlv_lossy<T: TryFrom<u16>>(&mut self) -> Result<Option<Tlv<T>>, CtlError> {
+        loop {
+            if let Some(tlv) = Self::try_parse_tlv_from_buffer_lossy::<T>(&mut self.mgmt_buffer)? {
+                return Ok(Some(tlv));
+            }
+
+            let mut chunk = [0u8; 256];
+            let n = match self.port_mut().read(&mut chunk).await {
+                Ok(n) => n,
+                Err(e) if P::is_timeout(&e) => return Ok(None),
+                Err(e) => return Err(CtlError::Port(format!("{:?}", e))),
+            };
+            if n == 0 {
+                return Ok(None);
+            }
+
+            let _ = self.mgmt_buffer.extend_from_slice(&chunk[..n]);
+        }
+    }
+
     /// Write a TLV to the port with sync word prefix.
     async fn write_tlv<T: Into<u16> + Copy>(
         &mut self,
@@ -400,6 +424,42 @@ impl<P: CtlPort> CtlCore<P> {
                 buffer.copy_within(1.., 0);
                 buffer.truncate(buffer.len() - 1);
                 Ok(None)
+            }
+        }
+    }
+
+    /// Try to parse a TLV from a stream buffer while tolerating malformed data.
+    fn try_parse_tlv_from_buffer_lossy<T: TryFrom<u16>>(
+        buffer: &mut Vec<u8>,
+    ) -> Result<Option<Tlv<T>>, CtlError> {
+        loop {
+            match buffer::try_parse_from_buffer(buffer) {
+                Ok(Some((tlv, consumed))) => {
+                    buffer.copy_within(consumed.., 0);
+                    buffer.truncate(buffer.len() - consumed);
+                    return Ok(Some(tlv));
+                }
+                Ok(None) => {
+                    if let Some(sync_pos) = buffer::find_sync_word(buffer) {
+                        if sync_pos > 0 {
+                            buffer.copy_within(sync_pos.., 0);
+                            buffer.truncate(buffer.len() - sync_pos);
+                        }
+                    } else {
+                        let keep = buffer.len().min(SYNC_WORD.len() - 1);
+                        let start = buffer.len() - keep;
+                        buffer.copy_within(start.., 0);
+                        buffer.truncate(keep);
+                    }
+                    return Ok(None);
+                }
+                Err(buffer::ParseError::InvalidType(_)) | Err(buffer::ParseError::TooLong) => {
+                    if buffer.is_empty() {
+                        return Ok(None);
+                    }
+                    buffer.copy_within(1.., 0);
+                    buffer.truncate(buffer.len() - 1);
+                }
             }
         }
     }
@@ -644,6 +704,11 @@ impl<P: CtlPort> CtlCore<P> {
     /// Read a raw TLV from the MGMT connection.
     pub async fn read_tlv_raw(&mut self) -> Result<Option<Tlv<MgmtToCtl>>, CtlError> {
         self.read_tlv().await
+    }
+
+    /// Read a raw TLV from the MGMT connection, skipping malformed packets.
+    pub async fn read_tlv_raw_lossy(&mut self) -> Result<Option<Tlv<MgmtToCtl>>, CtlError> {
+        self.read_tlv_lossy().await
     }
 
     // ========================================================================
@@ -1224,7 +1289,7 @@ impl<P: CtlPort> CtlCore<P> {
     /// Use this for polling scenarios where you expect timeouts.
     pub async fn try_read_ui_log(&mut self) -> Result<Option<String>, CtlError> {
         // First, try to parse a TLV from the existing buffer
-        if let Some(tlv) = Self::try_parse_tlv_from_buffer::<UiToCtl>(&mut self.ui_buffer)? {
+        if let Some(tlv) = Self::try_parse_tlv_from_buffer_lossy::<UiToCtl>(&mut self.ui_buffer)? {
             if tlv.tlv_type == UiToCtl::Log {
                 match core::str::from_utf8(&tlv.value) {
                     Ok(msg) => return Ok(Some(msg.into())),
@@ -1237,7 +1302,7 @@ impl<P: CtlPort> CtlCore<P> {
         }
 
         // Need more data - try to read from wire (returns None on timeout)
-        let Some(tlv) = self.read_tlv::<MgmtToCtl>().await? else {
+        let Some(tlv) = self.read_tlv_lossy::<MgmtToCtl>().await? else {
             return Ok(None); // Timeout/no data
         };
 
@@ -1262,7 +1327,9 @@ impl<P: CtlPort> CtlCore<P> {
     /// Try to read either a UI log line or raw NET data for monitor mode.
     pub async fn try_read_monitor_event(&mut self) -> Result<Option<MonitorEvent>, CtlError> {
         loop {
-            if let Some(tlv) = Self::try_parse_tlv_from_buffer::<UiToCtl>(&mut self.ui_buffer)? {
+            if let Some(tlv) =
+                Self::try_parse_tlv_from_buffer_lossy::<UiToCtl>(&mut self.ui_buffer)?
+            {
                 if tlv.tlv_type == UiToCtl::Log {
                     let msg = match core::str::from_utf8(&tlv.value) {
                         Ok(msg) => msg.into(),
@@ -1273,7 +1340,7 @@ impl<P: CtlPort> CtlCore<P> {
                 continue;
             }
 
-            let Some(tlv) = self.read_tlv::<MgmtToCtl>().await? else {
+            let Some(tlv) = self.read_tlv_lossy::<MgmtToCtl>().await? else {
                 return Ok(None);
             };
 

--- a/link/src/ctl/core.rs
+++ b/link/src/ctl/core.rs
@@ -13,7 +13,7 @@ use crate::shared::timing::reset::ESP32_RESET_HOLD_MS;
 use crate::shared::tlv::{buffer, tunnel};
 use crate::shared::{
     AdjDirection, CtlToMgmt, CtlToNet, CtlToUi, HEADER_SIZE, MgmtToCtl, NetLoopbackMode, NetToCtl,
-    SYNC_WORD, StackInfo, Tlv, UiLoopbackMode, UiToCtl, WifiSsid,
+    SYNC_WORD, StackInfo, Tlv, UiAudioReceivedPath, UiLoopbackMode, UiToCtl, WifiSsid,
 };
 
 use super::port::CtlPort;
@@ -1000,34 +1000,77 @@ impl<P: CtlPort> CtlCore<P> {
         Ok(tlv.value[0])
     }
 
-    /// Get UI chip audio routing mode.
-    pub async fn ui_get_audio_mode(&mut self) -> Result<crate::shared::AudioMode, CtlError> {
-        self.write_tlv_ui(CtlToUi::GetAudioMode, &[]).await?;
+    /// Get UI chip audio transmit mode.
+    pub async fn ui_get_audio_transmit_mode(
+        &mut self,
+    ) -> Result<crate::shared::AudioTransmitMode, CtlError> {
+        self.write_tlv_ui(CtlToUi::GetAudioTransmitMode, &[]).await?;
         let tlv = self.read_tlv_ui_skip_log().await?;
-        if tlv.tlv_type != UiToCtl::AudioMode {
+        if tlv.tlv_type != UiToCtl::AudioTransmitMode {
             return Err(CtlError::UnexpectedResponse {
-                expected: "AudioMode",
+                expected: "AudioTransmitMode",
                 actual: format!("{:?}", tlv.tlv_type),
             });
         }
         if tlv.value.is_empty() {
             return Err(CtlError::UnexpectedResponse {
-                expected: "AudioMode value",
+                expected: "AudioTransmitMode value",
                 actual: "empty".to_string(),
             });
         }
-        crate::shared::AudioMode::try_from(tlv.value[0]).map_err(|_| CtlError::UnexpectedResponse {
-            expected: "valid AudioMode",
+        crate::shared::AudioTransmitMode::try_from(tlv.value[0]).map_err(|_| {
+            CtlError::UnexpectedResponse {
+                expected: "valid AudioTransmitMode",
+                actual: format!("{}", tlv.value[0]),
+            }
+        })
+    }
+
+    /// Set UI chip audio transmit mode.
+    pub async fn ui_set_audio_transmit_mode(
+        &mut self,
+        mode: crate::shared::AudioTransmitMode,
+    ) -> Result<(), CtlError> {
+        self.write_tlv_ui(CtlToUi::SetAudioTransmitMode, &[mode as u8])
+            .await?;
+        let tlv = self.read_tlv_ui_skip_log().await?;
+        if tlv.tlv_type != UiToCtl::Ack {
+            return Err(CtlError::UnexpectedResponse {
+                expected: "Ack",
+                actual: format!("{:?}", tlv.tlv_type),
+            });
+        }
+        Ok(())
+    }
+
+    /// Get UI chip received audio output path.
+    pub async fn ui_get_audio_received_path(&mut self) -> Result<UiAudioReceivedPath, CtlError> {
+        self.write_tlv_ui(CtlToUi::GetAudioReceivedPath, &[]).await?;
+        let tlv = self.read_tlv_ui_skip_log().await?;
+        if tlv.tlv_type != UiToCtl::AudioReceivedPath {
+            return Err(CtlError::UnexpectedResponse {
+                expected: "AudioReceivedPath",
+                actual: format!("{:?}", tlv.tlv_type),
+            });
+        }
+        if tlv.value.is_empty() {
+            return Err(CtlError::UnexpectedResponse {
+                expected: "AudioReceivedPath value",
+                actual: "empty".to_string(),
+            });
+        }
+        UiAudioReceivedPath::try_from(tlv.value[0]).map_err(|_| CtlError::UnexpectedResponse {
+            expected: "valid UiAudioReceivedPath",
             actual: format!("{}", tlv.value[0]),
         })
     }
 
-    /// Set UI chip audio routing mode.
-    pub async fn ui_set_audio_mode(
+    /// Set UI chip received audio output path.
+    pub async fn ui_set_audio_received_path(
         &mut self,
-        mode: crate::shared::AudioMode,
+        path: UiAudioReceivedPath,
     ) -> Result<(), CtlError> {
-        self.write_tlv_ui(CtlToUi::SetAudioMode, &[mode as u8])
+        self.write_tlv_ui(CtlToUi::SetAudioReceivedPath, &[path as u8])
             .await?;
         let tlv = self.read_tlv_ui_skip_log().await?;
         if tlv.tlv_type != UiToCtl::Ack {

--- a/link/src/ctl/core.rs
+++ b/link/src/ctl/core.rs
@@ -12,8 +12,9 @@ use crate::shared::protocol_config::retries::MAX_TLV_SKIP;
 use crate::shared::timing::reset::ESP32_RESET_HOLD_MS;
 use crate::shared::tlv::{buffer, tunnel};
 use crate::shared::{
-    AdjDirection, CtlToMgmt, CtlToNet, CtlToUi, HEADER_SIZE, MgmtToCtl, NetLoopbackMode, NetToCtl,
-    SYNC_WORD, StackInfo, Tlv, UiAudioReceivedPath, UiLoopbackMode, UiToCtl, WifiSsid,
+    AdjDirection, CtlToMgmt, CtlToNet, CtlToUi, HEADER_SIZE, MAX_VALUE_SIZE, MgmtToCtl,
+    NetLoopbackMode, NetToCtl, SYNC_WORD, StackInfo, Tlv, UiAudioReceivedPath, UiLoopbackMode,
+    UiToCtl, WifiSsid,
 };
 
 use super::port::CtlPort;
@@ -862,6 +863,27 @@ impl<P: CtlPort> CtlCore<P> {
         Ok(UiLoopbackMode::try_from(mode_byte).unwrap_or(UiLoopbackMode::Off))
     }
 
+    /// Send a blaster payload to the UI chip and wait for an acknowledgment.
+    pub async fn ui_blaster_send(&mut self, payload: &[u8]) -> Result<(), CtlError> {
+        if payload.len() > MAX_VALUE_SIZE {
+            return Err(CtlError::TooLong);
+        }
+
+        self.write_tlv_ui(CtlToUi::BlasterSend, payload).await?;
+        let tlv = self.read_tlv_ui_skip_log().await?;
+        if tlv.tlv_type == UiToCtl::Error {
+            let msg = core::str::from_utf8(&tlv.value).unwrap_or("unknown error");
+            return Err(CtlError::DeviceError(msg.into()));
+        }
+        if tlv.tlv_type != UiToCtl::Ack {
+            return Err(CtlError::UnexpectedResponse {
+                expected: "Ack",
+                actual: format!("{:?}", tlv.tlv_type),
+            });
+        }
+        Ok(())
+    }
+
     /// Get UI chip stack usage information.
     pub async fn ui_get_stack_info(&mut self) -> Result<StackInfo, CtlError> {
         self.write_tlv_ui(CtlToUi::GetStackInfo, &[]).await?;
@@ -1447,6 +1469,62 @@ impl<P: CtlPort> CtlCore<P> {
         }
         let mode_byte = tlv.value.first().copied().unwrap_or(0);
         Ok(NetLoopbackMode::try_from(mode_byte).unwrap_or(NetLoopbackMode::Off))
+    }
+
+    /// Send a blaster payload to the NET chip and wait for an acknowledgment.
+    pub async fn net_blaster_send(&mut self, payload: &[u8]) -> Result<(), CtlError> {
+        if payload.len() > MAX_VALUE_SIZE {
+            return Err(CtlError::TooLong);
+        }
+
+        self.write_tlv_net(CtlToNet::BlasterSend, payload).await?;
+        let tlv = self.read_tlv_net().await?;
+        if tlv.tlv_type == NetToCtl::Error {
+            let msg = core::str::from_utf8(&tlv.value).unwrap_or("unknown error");
+            return Err(CtlError::DeviceError(msg.into()));
+        }
+        if tlv.tlv_type != NetToCtl::Ack {
+            return Err(CtlError::UnexpectedResponse {
+                expected: "Ack",
+                actual: format!("{:?}", tlv.tlv_type),
+            });
+        }
+        Ok(())
+    }
+
+    /// Get the NET blaster enabled state.
+    pub async fn net_get_blaster(&mut self) -> Result<bool, CtlError> {
+        self.write_tlv_net(CtlToNet::GetBlaster, &[]).await?;
+        let tlv = self.read_tlv_net().await?;
+        if tlv.tlv_type == NetToCtl::Error {
+            let msg = core::str::from_utf8(&tlv.value).unwrap_or("unknown error");
+            return Err(CtlError::DeviceError(msg.into()));
+        }
+        if tlv.tlv_type != NetToCtl::Blaster {
+            return Err(CtlError::UnexpectedResponse {
+                expected: "Blaster",
+                actual: format!("{:?}", tlv.tlv_type),
+            });
+        }
+        Ok(tlv.value.first().copied().unwrap_or(0) != 0)
+    }
+
+    /// Set the NET blaster enabled state.
+    pub async fn net_set_blaster(&mut self, enabled: bool) -> Result<(), CtlError> {
+        self.write_tlv_net(CtlToNet::SetBlaster, &[enabled as u8])
+            .await?;
+        let tlv = self.read_tlv_net().await?;
+        if tlv.tlv_type == NetToCtl::Error {
+            let msg = core::str::from_utf8(&tlv.value).unwrap_or("unknown error");
+            return Err(CtlError::DeviceError(msg.into()));
+        }
+        if tlv.tlv_type != NetToCtl::Ack {
+            return Err(CtlError::UnexpectedResponse {
+                expected: "Ack",
+                actual: format!("{:?}", tlv.tlv_type),
+            });
+        }
+        Ok(())
     }
 
     /// Add a WiFi SSID and password pair to NET chip storage.

--- a/link/src/ctl/core.rs
+++ b/link/src/ctl/core.rs
@@ -1492,8 +1492,8 @@ impl<P: CtlPort> CtlCore<P> {
         Ok(())
     }
 
-    /// Get the NET blaster enabled state.
-    pub async fn net_get_blaster(&mut self) -> Result<bool, CtlError> {
+    /// Get the NET blaster state.
+    pub async fn net_get_blaster(&mut self) -> Result<(bool, i16), CtlError> {
         self.write_tlv_net(CtlToNet::GetBlaster, &[]).await?;
         let tlv = self.read_tlv_net().await?;
         if tlv.tlv_type == NetToCtl::Error {
@@ -1506,12 +1506,27 @@ impl<P: CtlPort> CtlCore<P> {
                 actual: format!("{:?}", tlv.tlv_type),
             });
         }
-        Ok(tlv.value.first().copied().unwrap_or(0) != 0)
+
+        if tlv.value.len() != 3 {
+            return Err(CtlError::InvalidLength {
+                expected: 3,
+                actual: tlv.value.len(),
+            });
+        }
+
+        let enabled = tlv.value[0] != 0;
+        let blaster_size = i16::from_le_bytes([tlv.value[1], tlv.value[2]]);
+        Ok((enabled, blaster_size))
     }
 
-    /// Set the NET blaster enabled state.
-    pub async fn net_set_blaster(&mut self, enabled: bool) -> Result<(), CtlError> {
-        self.write_tlv_net(CtlToNet::SetBlaster, &[enabled as u8])
+    /// Set the NET blaster state.
+    pub async fn net_set_blaster(
+        &mut self,
+        enabled: bool,
+        blaster_size: i16,
+    ) -> Result<(), CtlError> {
+        let size = blaster_size.to_le_bytes();
+        self.write_tlv_net(CtlToNet::SetBlaster, &[enabled as u8, size[0], size[1]])
             .await?;
         let tlv = self.read_tlv_net().await?;
         if tlv.tlv_type == NetToCtl::Error {

--- a/link/src/integration_tests.rs
+++ b/link/src/integration_tests.rs
@@ -13,7 +13,7 @@ use crate::shared::mocks::{
     MockPin, TrackingPin, async_async_channel, ctl_async_channel, mock_i2c_with_eeprom,
     mock_led_pins,
 };
-use crate::{NetLoopbackMode, PinValue, UiLoopbackMode, mgmt, net, ui};
+use crate::{NetLoopbackMode, PinValue, UiAudioReceivedPath, UiLoopbackMode, mgmt, net, ui};
 use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
 use embassy_sync::channel::Channel;
 use std::sync::{Arc, Mutex};
@@ -481,6 +481,39 @@ async fn ui_loopback_set_sframe() {
         ctl.ui_set_loopback(UiLoopbackMode::Sframe).await.unwrap();
         let mode = ctl.ui_get_loopback().await.unwrap();
         assert_eq!(mode, UiLoopbackMode::Sframe);
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn ui_audio_received_path_default_headphones() {
+    device_test(|mut ctl| async move {
+        let path = ctl.ui_get_audio_received_path().await.unwrap();
+        assert_eq!(path, UiAudioReceivedPath::Headphones);
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn ui_audio_received_path_set_ctl() {
+    device_test(|mut ctl| async move {
+        ctl.ui_set_audio_received_path(UiAudioReceivedPath::Ctl)
+            .await
+            .unwrap();
+        let path = ctl.ui_get_audio_received_path().await.unwrap();
+        assert_eq!(path, UiAudioReceivedPath::Ctl);
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn ui_audio_received_path_set_both() {
+    device_test(|mut ctl| async move {
+        ctl.ui_set_audio_received_path(UiAudioReceivedPath::Both)
+            .await
+            .unwrap();
+        let path = ctl.ui_get_audio_received_path().await.unwrap();
+        assert_eq!(path, UiAudioReceivedPath::Both);
     })
     .await;
 }

--- a/link/src/lib.rs
+++ b/link/src/lib.rs
@@ -52,8 +52,9 @@ pub use shared::wifi::WifiSsid;
 
 // Re-export protocol types
 pub use shared::protocol::{
-    AdjDirection, AudioMode, ChannelId, CtlToMgmt, CtlToNet, CtlToUi, MgmtToCtl, NetLoopbackMode,
-    NetToCtl, NetToUi, Pin, PinValue, StackInfo, UiLoopbackMode, UiToCtl, UiToNet,
+    AdjDirection, AudioTransmitMode, ChannelId, CtlToMgmt, CtlToNet, CtlToUi, MgmtToCtl,
+    NetLoopbackMode, NetToCtl, NetToUi, Pin, PinValue, StackInfo, UiAudioReceivedPath,
+    UiLoopbackMode, UiToCtl, UiToNet,
 };
 
 // Re-export logging macros (crate-internal, no-op when defmt disabled)

--- a/link/src/net/mod.rs
+++ b/link/src/net/mod.rs
@@ -178,6 +178,7 @@ where
         let mut ws_mode = WsMode::Normal;
         let mut loopback = NetLoopbackMode::Off;
         let mut blaster_enabled = false;
+        let mut blaster_size = -1i16;
         let mut wifi_connected = false;
         let mut ws_connected = false;
         // Per-channel jitter buffers
@@ -198,6 +199,7 @@ where
                             &mut ws_mode,
                             &mut loopback,
                             &mut blaster_enabled,
+                            &mut blaster_size,
                         )
                         .await
                     }
@@ -247,6 +249,7 @@ where
         let mut ws_mode = WsMode::Normal;
         let mut loopback = NetLoopbackMode::Off;
         let mut blaster_enabled = false;
+        let mut blaster_size = -1i16;
         let mut wifi_connected = false;
         let mut ws_connected = false;
         info!("net: ready to handle events");
@@ -262,6 +265,7 @@ where
                         &mut ws_mode,
                         &mut loopback,
                         &mut blaster_enabled,
+                        &mut blaster_size,
                     )
                     .await
                 }
@@ -298,6 +302,7 @@ async fn handle_mgmt<'a, M, U, F, RM: RawMutex, const N: usize>(
     _ws_mode: &mut WsMode,
     loopback: &mut NetLoopbackMode,
     blaster_enabled: &mut bool,
+    blaster_size: &mut i16,
 ) where
     M: WriteTlv<NetToCtl>,
     U: WriteTlv<NetToUi>,
@@ -411,14 +416,32 @@ async fn handle_mgmt<'a, M, U, F, RM: RawMutex, const N: usize>(
                 .await;
         }
         CtlToNet::GetBlaster => {
-            info!("net: get blaster = {}", *blaster_enabled);
+            info!(
+                "net: get blaster = {}, size = {}",
+                *blaster_enabled, *blaster_size
+            );
             to_mgmt
-                .must_write_tlv(NetToCtl::Blaster, &[*blaster_enabled as u8])
+                .must_write_tlv(
+                    NetToCtl::Blaster,
+                    &[
+                        *blaster_enabled as u8,
+                        blaster_size.to_le_bytes()[0],
+                        blaster_size.to_le_bytes()[1],
+                    ],
+                )
                 .await;
         }
         CtlToNet::SetBlaster => {
             *blaster_enabled = tlv.value.first().copied().unwrap_or(0) != 0;
-            info!("net: set blaster = {}", *blaster_enabled);
+            if tlv.value.len() >= 3 {
+                *blaster_size = i16::from_le_bytes([tlv.value[1], tlv.value[2]]);
+            } else {
+                *blaster_size = -1;
+            }
+            info!(
+                "net: set blaster = {}, size = {}",
+                *blaster_enabled, *blaster_size
+            );
             to_mgmt.must_write_tlv(NetToCtl::Ack, &[]).await;
         }
         CtlToNet::GetLogsEnabled => {
@@ -879,6 +902,7 @@ mod tests {
         let mut ws_mode = WsMode::Normal;
         let mut loopback = NetLoopbackMode::Off;
         let mut blaster_enabled = false;
+        let mut blaster_size = -1i16;
 
         let tlv = Tlv {
             tlv_type: CtlToNet::Ping,
@@ -894,6 +918,7 @@ mod tests {
             &mut ws_mode,
             &mut loopback,
             &mut blaster_enabled,
+            &mut blaster_size,
         )
         .await;
 
@@ -911,6 +936,7 @@ mod tests {
         let mut ws_mode = WsMode::Normal;
         let mut loopback = NetLoopbackMode::Off;
         let mut blaster_enabled = false;
+        let mut blaster_size = -1i16;
 
         let tlv = Tlv {
             tlv_type: CtlToNet::SetRelayUrl,
@@ -926,6 +952,7 @@ mod tests {
             &mut ws_mode,
             &mut loopback,
             &mut blaster_enabled,
+            &mut blaster_size,
         )
         .await;
 
@@ -955,6 +982,7 @@ mod tests {
         let mut ws_mode = WsMode::Normal;
         let mut loopback = NetLoopbackMode::Off;
         let mut blaster_enabled = false;
+        let mut blaster_size = -1i16;
 
         let tlv = Tlv {
             tlv_type: CtlToNet::GetRelayUrl,
@@ -970,6 +998,7 @@ mod tests {
             &mut ws_mode,
             &mut loopback,
             &mut blaster_enabled,
+            &mut blaster_size,
         )
         .await;
 
@@ -987,6 +1016,7 @@ mod tests {
         let mut ws_mode = WsMode::Normal;
         let mut loopback = NetLoopbackMode::Off;
         let mut blaster_enabled = false;
+        let mut blaster_size = -1i16;
 
         let tlv = Tlv {
             tlv_type: CtlToNet::BlasterSend,
@@ -1002,6 +1032,7 @@ mod tests {
             &mut ws_mode,
             &mut loopback,
             &mut blaster_enabled,
+            &mut blaster_size,
         )
         .await;
 
@@ -1018,11 +1049,12 @@ mod tests {
         let mut ws_mode = WsMode::Normal;
         let mut loopback = NetLoopbackMode::Off;
         let mut blaster_enabled = false;
+        let mut blaster_size = -1i16;
 
         handle_mgmt(
             Tlv {
                 tlv_type: CtlToNet::SetBlaster,
-                value: heapless::Vec::from_slice(&[1]).unwrap(),
+                value: heapless::Vec::from_slice(&[1, 100, 0]).unwrap(),
             },
             &mut to_mgmt,
             &mut to_ui,
@@ -1031,6 +1063,7 @@ mod tests {
             &mut ws_mode,
             &mut loopback,
             &mut blaster_enabled,
+            &mut blaster_size,
         )
         .await;
 
@@ -1046,13 +1079,15 @@ mod tests {
             &mut ws_mode,
             &mut loopback,
             &mut blaster_enabled,
+            &mut blaster_size,
         )
         .await;
 
         assert_eq!(to_mgmt.written[0].0, NetToCtl::Ack);
         assert_eq!(to_mgmt.written[1].0, NetToCtl::Blaster);
-        assert_eq!(to_mgmt.written[1].1, &[1]);
+        assert_eq!(to_mgmt.written[1].1, &[1, 100, 0]);
         assert!(blaster_enabled);
+        assert_eq!(blaster_size, 100);
     }
 
     // ==================== WsCommand/WsEvent Construction Tests ====================

--- a/link/src/net/mod.rs
+++ b/link/src/net/mod.rs
@@ -177,6 +177,7 @@ where
     let handle_task = async {
         let mut ws_mode = WsMode::Normal;
         let mut loopback = NetLoopbackMode::Off;
+        let mut blaster_enabled = false;
         let mut wifi_connected = false;
         let mut ws_connected = false;
         // Per-channel jitter buffers
@@ -196,6 +197,7 @@ where
                             &ws_cmd_tx,
                             &mut ws_mode,
                             &mut loopback,
+                            &mut blaster_enabled,
                         )
                         .await
                     }
@@ -244,6 +246,7 @@ where
     let handle_task = async {
         let mut ws_mode = WsMode::Normal;
         let mut loopback = NetLoopbackMode::Off;
+        let mut blaster_enabled = false;
         let mut wifi_connected = false;
         let mut ws_connected = false;
         info!("net: ready to handle events");
@@ -258,6 +261,7 @@ where
                         &ws_cmd_tx,
                         &mut ws_mode,
                         &mut loopback,
+                        &mut blaster_enabled,
                     )
                     .await
                 }
@@ -293,6 +297,7 @@ async fn handle_mgmt<'a, M, U, F, RM: RawMutex, const N: usize>(
     ws_cmd_tx: &Sender<'a, RM, WsCommand, N>,
     _ws_mode: &mut WsMode,
     loopback: &mut NetLoopbackMode,
+    blaster_enabled: &mut bool,
 ) where
     M: WriteTlv<NetToCtl>,
     U: WriteTlv<NetToUi>,
@@ -395,11 +400,26 @@ async fn handle_mgmt<'a, M, U, F, RM: RawMutex, const N: usize>(
             *loopback = mode;
             to_mgmt.must_write_tlv(NetToCtl::Ack, &[]).await;
         }
+        CtlToNet::BlasterSend => {
+            info!("net: blaster send ({} bytes)", tlv.value.len());
+            to_mgmt.must_write_tlv(NetToCtl::Ack, &[]).await;
+        }
         CtlToNet::GetLoopback => {
             info!("net: get loopback = {}", *loopback);
             to_mgmt
                 .must_write_tlv(NetToCtl::Loopback, &[*loopback as u8])
                 .await;
+        }
+        CtlToNet::GetBlaster => {
+            info!("net: get blaster = {}", *blaster_enabled);
+            to_mgmt
+                .must_write_tlv(NetToCtl::Blaster, &[*blaster_enabled as u8])
+                .await;
+        }
+        CtlToNet::SetBlaster => {
+            *blaster_enabled = tlv.value.first().copied().unwrap_or(0) != 0;
+            info!("net: set blaster = {}", *blaster_enabled);
+            to_mgmt.must_write_tlv(NetToCtl::Ack, &[]).await;
         }
         CtlToNet::GetLogsEnabled => {
             info!("net: get logs enabled");
@@ -858,6 +878,7 @@ mod tests {
         let channel: Channel<CriticalSectionRawMutex, WsCommand, 4> = Channel::new();
         let mut ws_mode = WsMode::Normal;
         let mut loopback = NetLoopbackMode::Off;
+        let mut blaster_enabled = false;
 
         let tlv = Tlv {
             tlv_type: CtlToNet::Ping,
@@ -872,6 +893,7 @@ mod tests {
             &channel.sender(),
             &mut ws_mode,
             &mut loopback,
+            &mut blaster_enabled,
         )
         .await;
 
@@ -888,6 +910,7 @@ mod tests {
         let channel: Channel<CriticalSectionRawMutex, WsCommand, 4> = Channel::new();
         let mut ws_mode = WsMode::Normal;
         let mut loopback = NetLoopbackMode::Off;
+        let mut blaster_enabled = false;
 
         let tlv = Tlv {
             tlv_type: CtlToNet::SetRelayUrl,
@@ -902,6 +925,7 @@ mod tests {
             &channel.sender(),
             &mut ws_mode,
             &mut loopback,
+            &mut blaster_enabled,
         )
         .await;
 
@@ -930,6 +954,7 @@ mod tests {
         let channel: Channel<CriticalSectionRawMutex, WsCommand, 4> = Channel::new();
         let mut ws_mode = WsMode::Normal;
         let mut loopback = NetLoopbackMode::Off;
+        let mut blaster_enabled = false;
 
         let tlv = Tlv {
             tlv_type: CtlToNet::GetRelayUrl,
@@ -944,12 +969,90 @@ mod tests {
             &channel.sender(),
             &mut ws_mode,
             &mut loopback,
+            &mut blaster_enabled,
         )
         .await;
 
         assert_eq!(to_mgmt.written.len(), 1);
         assert_eq!(to_mgmt.written[0].0, NetToCtl::RelayUrl);
         assert_eq!(to_mgmt.written[0].1, b"wss://test.relay");
+    }
+
+    #[tokio::test]
+    async fn handle_mgmt_blaster_send_returns_ack() {
+        let mut to_mgmt = MockMgmtWriter::new();
+        let mut to_ui = MockUiWriter::new();
+        let mut storage = NetStorage::new(MockFlash::new(), 0);
+        let channel: Channel<CriticalSectionRawMutex, WsCommand, 4> = Channel::new();
+        let mut ws_mode = WsMode::Normal;
+        let mut loopback = NetLoopbackMode::Off;
+        let mut blaster_enabled = false;
+
+        let tlv = Tlv {
+            tlv_type: CtlToNet::BlasterSend,
+            value: heapless::Vec::from_slice(&[0x55; 16]).unwrap(),
+        };
+
+        handle_mgmt(
+            tlv,
+            &mut to_mgmt,
+            &mut to_ui,
+            &mut storage,
+            &channel.sender(),
+            &mut ws_mode,
+            &mut loopback,
+            &mut blaster_enabled,
+        )
+        .await;
+
+        assert_eq!(to_mgmt.written.len(), 1);
+        assert_eq!(to_mgmt.written[0].0, NetToCtl::Ack);
+    }
+
+    #[tokio::test]
+    async fn handle_mgmt_set_and_get_blaster() {
+        let mut to_mgmt = MockMgmtWriter::new();
+        let mut to_ui = MockUiWriter::new();
+        let mut storage = NetStorage::new(MockFlash::new(), 0);
+        let channel: Channel<CriticalSectionRawMutex, WsCommand, 4> = Channel::new();
+        let mut ws_mode = WsMode::Normal;
+        let mut loopback = NetLoopbackMode::Off;
+        let mut blaster_enabled = false;
+
+        handle_mgmt(
+            Tlv {
+                tlv_type: CtlToNet::SetBlaster,
+                value: heapless::Vec::from_slice(&[1]).unwrap(),
+            },
+            &mut to_mgmt,
+            &mut to_ui,
+            &mut storage,
+            &channel.sender(),
+            &mut ws_mode,
+            &mut loopback,
+            &mut blaster_enabled,
+        )
+        .await;
+
+        handle_mgmt(
+            Tlv {
+                tlv_type: CtlToNet::GetBlaster,
+                value: heapless::Vec::new(),
+            },
+            &mut to_mgmt,
+            &mut to_ui,
+            &mut storage,
+            &channel.sender(),
+            &mut ws_mode,
+            &mut loopback,
+            &mut blaster_enabled,
+        )
+        .await;
+
+        assert_eq!(to_mgmt.written[0].0, NetToCtl::Ack);
+        assert_eq!(to_mgmt.written[1].0, NetToCtl::Blaster);
+        assert_eq!(to_mgmt.written[1].1, &[1]);
+        assert!(blaster_enabled);
     }
 
     // ==================== WsCommand/WsEvent Construction Tests ====================

--- a/link/src/shared/protocol.rs
+++ b/link/src/shared/protocol.rs
@@ -78,7 +78,7 @@ impl core::fmt::Display for UiLoopbackMode {
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Default, IntoPrimitive, TryFromPrimitive)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(u8)]
-pub enum AudioMode {
+pub enum AudioTransmitMode {
     /// Audio routed to/from NET chip (normal operation)
     #[default]
     Net = 0,
@@ -87,12 +87,39 @@ pub enum AudioMode {
     Both,
 }
 
-impl core::fmt::Display for AudioMode {
+impl core::fmt::Display for AudioTransmitMode {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
-            AudioMode::Net => write!(f, "net"),
-            AudioMode::Ctl => write!(f, "ctl"),
-            AudioMode::Both => write!(f, "both"),
+            AudioTransmitMode::Net => write!(f, "net"),
+            AudioTransmitMode::Ctl => write!(f, "ctl"),
+            AudioTransmitMode::Both => write!(f, "both"),
+        }
+    }
+}
+
+/// Output path for audio received by the UI chip from NET.
+#[derive(Copy, Clone, PartialEq, Eq, Debug, Default, IntoPrimitive, TryFromPrimitive)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[repr(u8)]
+pub enum UiAudioReceivedPath {
+    /// Drop received audio.
+    None = 0,
+    /// Play received audio through the UI headphones path.
+    #[default]
+    Headphones,
+    /// Forward received audio to CTL via MGMT.
+    Ctl,
+    /// Forward received audio to CTL and play it locally.
+    Both,
+}
+
+impl core::fmt::Display for UiAudioReceivedPath {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            UiAudioReceivedPath::None => write!(f, "none"),
+            UiAudioReceivedPath::Headphones => write!(f, "headphones"),
+            UiAudioReceivedPath::Ctl => write!(f, "ctl"),
+            UiAudioReceivedPath::Both => write!(f, "both"),
         }
     }
 }
@@ -228,10 +255,14 @@ pub enum CtlToUi {
     SetMicPreamp,
     /// Adjust microphone preamp level (2 bytes: AdjMicPreamp, amount)
     AdjMicPreamp,
-    /// Get audio routing mode (returns AudioMode)
-    GetAudioMode,
-    /// Set audio routing mode (1 byte: AudioMode - 0=Net, 1=Ctl)
-    SetAudioMode,
+    /// Get audio transmit mode (returns AudioTransmitMode)
+    GetAudioTransmitMode,
+    /// Set audio transmit mode (1 byte: AudioTransmitMode - 0=Net, 1=Ctl)
+    SetAudioTransmitMode,
+    /// Get received audio output path (returns UiAudioReceivedPath)
+    GetAudioReceivedPath,
+    /// Set received audio output path (1 byte: UiAudioReceivedPath)
+    SetAudioReceivedPath,
     /// Audio frame from CTL to play out (when audio-mode=ctl)
     AudioFrame,
     /// Audio stream start marker from CTL
@@ -261,8 +292,10 @@ pub enum UiToCtl {
     Volume,
     /// Microphone preamp level (1 byte: u8)
     MicPreamp,
-    /// Audio routing mode (1 byte: AudioMode - 0=Net, 1=Ctl)
-    AudioMode,
+    /// Audio transmit mode (1 byte: AudioTransmitMode - 0=Net, 1=Ctl)
+    AudioTransmitMode,
+    /// Received audio output path (1 byte: UiAudioReceivedPath)
+    AudioReceivedPath,
     /// Audio capture started (button pressed) - sent when audio-mode=ctl
     AudioStart,
     /// Audio capture ended (button released) - sent when audio-mode=ctl
@@ -270,6 +303,9 @@ pub enum UiToCtl {
     /// Audio frame from UI mic (when audio-mode=ctl)
     /// Format: [channel_id: u8][sframe_header][encrypted_chunk][auth_tag]
     AudioFrame,
+    /// Audio frame that has already been SFrame-decrypted by UI.
+    /// Format: [channel_id: u8][media_chunk]
+    AudioFrameUnprotected,
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, IntoPrimitive, TryFromPrimitive)]

--- a/link/src/shared/protocol.rs
+++ b/link/src/shared/protocol.rs
@@ -346,7 +346,7 @@ pub enum CtlToNet {
     BlasterSend,
     /// Get NET blaster enabled state
     GetBlaster,
-    /// Set NET blaster enabled state (1 byte: 0=off, 1=on)
+    /// Set NET blaster state (3 bytes: enabled u8, blaster_size i16 LE)
     SetBlaster,
     /// Burn JTAG/USB disable efuse (IRREVERSIBLE!)
     BurnJtagEfuse,
@@ -371,7 +371,7 @@ pub enum NetToCtl {
     Channel,
     /// AI configuration (JSON object)
     Ai,
-    /// NET blaster enabled state (1 byte: 0=off, 1=on)
+    /// NET blaster state (3 bytes: enabled u8, blaster_size i16 LE)
     Blaster,
 }
 

--- a/link/src/shared/protocol.rs
+++ b/link/src/shared/protocol.rs
@@ -269,6 +269,8 @@ pub enum CtlToUi {
     AudioStart,
     /// Audio stream end marker from CTL
     AudioEnd,
+    /// Test payload for UART blasting (raw bytes, up to 640 bytes)
+    BlasterSend,
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, IntoPrimitive, TryFromPrimitive)]
@@ -340,6 +342,12 @@ pub enum CtlToNet {
     GetAi,
     /// Set AI configuration (JSON object: {"query":[...],"audio":[...],"cmd":[...]})
     SetAi,
+    /// Test payload for UART blasting (raw bytes, up to 640 bytes)
+    BlasterSend,
+    /// Get NET blaster enabled state
+    GetBlaster,
+    /// Set NET blaster enabled state (1 byte: 0=off, 1=on)
+    SetBlaster,
     /// Burn JTAG/USB disable efuse (IRREVERSIBLE!)
     BurnJtagEfuse,
 }
@@ -363,6 +371,8 @@ pub enum NetToCtl {
     Channel,
     /// AI configuration (JSON object)
     Ai,
+    /// NET blaster enabled state (1 byte: 0=off, 1=on)
+    Blaster,
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, IntoPrimitive, TryFromPrimitive)]

--- a/link/src/ui/mod.rs
+++ b/link/src/ui/mod.rs
@@ -562,6 +562,10 @@ async fn handle_mgmt<M, N, I, D, B, const PLAYBACK_N: usize>(
             info!("ui: get loopback = {}", mode);
             to_mgmt.must_write_tlv(UiToCtl::Loopback, &[mode]).await;
         }
+        CtlToUi::BlasterSend => {
+            info!("ui: blaster send ({} bytes)", tlv.value.len());
+            to_mgmt.must_write_tlv(UiToCtl::Ack, &[]).await;
+        }
         CtlToUi::GetStackInfo => {
             info!("ui: get stack info");
             use crate::shared::StackInfo;
@@ -1028,6 +1032,48 @@ mod tests {
         assert_eq!(to_mgmt.written[0].0, UiToCtl::Ack);
         let mut eeprom = Eeprom::new(&mut i2c, &mut delay);
         assert_eq!(eeprom.get_sframe_key().unwrap(), key);
+    }
+
+    #[tokio::test]
+    async fn tlv_blaster_send_returns_ack() {
+        let mut to_mgmt = MockTlvWriter::new();
+        let mut to_net = DummyNetWriter;
+        let mut i2c = mock_i2c_with_eeprom();
+        let mut delay = MockDelay;
+
+        let tlv = Tlv {
+            tlv_type: CtlToUi::BlasterSend,
+            value: Value::from_slice(&[0x55; 32]).unwrap(),
+        };
+
+        let loopback_mode = AtomicU8::new(UiLoopbackMode::Off as u8);
+        let logs_enabled = AtomicBool::new(true);
+        let volume = AtomicU8::new(255);
+        let audio_mode = AtomicU8::new(AudioTransmitMode::Net as u8);
+        let audio_received_path = AtomicU8::new(UiAudioReceivedPath::Headphones as u8);
+        let playback_channel: Channel<CriticalSectionRawMutex, Frame, 4> = Channel::new();
+        let mic_preamp = AtomicU8::new(255);
+        let mut sframe_state = sframe::SFrameState::new(&[0u8; 16], 0);
+        handle_mgmt(
+            tlv,
+            &mut to_mgmt,
+            &mut to_net,
+            &mut i2c,
+            &mut delay,
+            &loopback_mode,
+            &logs_enabled,
+            &volume,
+            &audio_mode,
+            &audio_received_path,
+            &mic_preamp,
+            &mut sframe_state,
+            &playback_channel,
+            &crate::shared::NoOpBoard,
+        )
+        .await;
+
+        assert_eq!(to_mgmt.written.len(), 1);
+        assert_eq!(to_mgmt.written[0].0, UiToCtl::Ack);
     }
 
     #[tokio::test]

--- a/link/src/ui/mod.rs
+++ b/link/src/ui/mod.rs
@@ -17,9 +17,9 @@ pub use log::{LogMessage, LogSender, MAX_LOG_SIZE};
 
 use crate::info;
 use crate::shared::{
-    AdjDirection, AudioMode, Channel, ChannelId, Color, CriticalSectionRawMutex, CtlToUi, Led,
-    NetToUi, Sender, StackMonitor, Tlv, UiAudioReceivedPath, UiLoopbackMode, UiToCtl, UiToNet,
-    WriteTlv, chunk, read_tlv_loop,
+    AdjDirection, AudioTransmitMode, Channel, ChannelId, Color, CriticalSectionRawMutex,
+    CtlToUi, Led, NetToUi, Sender, StackMonitor, Tlv, UiAudioReceivedPath, UiLoopbackMode,
+    UiToCtl, UiToNet, WriteTlv, chunk, read_tlv_loop,
 };
 
 /// Board trait for UI chip.
@@ -118,7 +118,7 @@ where
     let volume = AtomicU8::new(255);
 
     // Shared audio routing mode (Net or Ctl)
-    let audio_mode = AtomicU8::new(AudioMode::Net as u8);
+    let audio_mode = AtomicU8::new(AudioTransmitMode::Net as u8);
     // Shared output path for audio received from NET.
     let audio_received_path = AtomicU8::new(UiAudioReceivedPath::Headphones as u8);
     // Shared microphone preamp level (TODO: actually configure the audio system)
@@ -166,9 +166,9 @@ where
                     // Handle audio frames specially - they need decryption
                     if tlv.tlv_type == NetToUi::AudioFrame {
                         // Drop audio from NET when audio-mode=ctl
-                        let mode = AudioMode::try_from(audio_mode.load(Ordering::Relaxed))
-                            .unwrap_or(AudioMode::Net);
-                        if mode == AudioMode::Ctl {
+                        let mode = AudioTransmitMode::try_from(audio_mode.load(Ordering::Relaxed))
+                            .unwrap_or(AudioTransmitMode::Net);
+                        if mode == AudioTransmitMode::Ctl {
                             continue;
                         }
 
@@ -226,9 +226,9 @@ where
                         button_active.store(true, Ordering::Relaxed);
 
                         // Emit AudioStart to CTL or NET depending on mode
-                        let mode = AudioMode::try_from(audio_mode.load(Ordering::Relaxed))
-                            .unwrap_or(AudioMode::Net);
-                        if mode == AudioMode::Ctl {
+                        let mode = AudioTransmitMode::try_from(audio_mode.load(Ordering::Relaxed))
+                            .unwrap_or(AudioTransmitMode::Net);
+                        if mode == AudioTransmitMode::Ctl {
                             to_mgmt.must_write_tlv(UiToCtl::AudioStart, &[]).await;
                         } else {
                             to_net.must_write_tlv(UiToNet::AudioStart, &[]).await;
@@ -243,9 +243,9 @@ where
                         button_active.store(false, Ordering::Relaxed);
 
                         // Emit AudioEnd to CTL or NET depending on mode
-                        let mode = AudioMode::try_from(audio_mode.load(Ordering::Relaxed))
-                            .unwrap_or(AudioMode::Net);
-                        if mode == AudioMode::Ctl {
+                        let mode = AudioTransmitMode::try_from(audio_mode.load(Ordering::Relaxed))
+                            .unwrap_or(AudioTransmitMode::Net);
+                        if mode == AudioTransmitMode::Ctl {
                             to_mgmt.must_write_tlv(UiToCtl::AudioEnd, &[]).await;
                         } else {
                             to_net.must_write_tlv(UiToNet::AudioEnd, &[]).await;
@@ -327,11 +327,11 @@ where
                     }
 
                     // Route based on audio mode
-                    let audio_routing = AudioMode::try_from(audio_mode.load(Ordering::Relaxed))
-                        .unwrap_or(AudioMode::Net);
+                    let audio_routing = AudioTransmitMode::try_from(audio_mode.load(Ordering::Relaxed))
+                        .unwrap_or(AudioTransmitMode::Net);
                     let channel_id_byte = [channel_id as u8];
 
-                    if audio_routing == AudioMode::Ctl {
+                    if audio_routing == AudioTransmitMode::Ctl {
                         // Send to CTL via MGMT: channel_id (plaintext) + encrypted chunk
                         to_mgmt
                             .must_write_tlv_parts(UiToCtl::AudioFrame, &[&channel_id_byte, &buf])
@@ -622,15 +622,15 @@ async fn handle_mgmt<M, N, I, D, B, const PLAYBACK_N: usize>(
             volume.store(vol, Ordering::Relaxed);
             to_mgmt.must_write_tlv(UiToCtl::Ack, &[]).await;
         }
-        CtlToUi::GetAudioMode => {
-            info!("ui: get audio mode");
+        CtlToUi::GetAudioTransmitMode => {
+            info!("ui: get audio transmit mode");
             let mode = audio_mode.load(Ordering::Relaxed);
-            to_mgmt.must_write_tlv(UiToCtl::AudioMode, &[mode]).await;
+            to_mgmt.must_write_tlv(UiToCtl::AudioTransmitMode, &[mode]).await;
         }
-        CtlToUi::SetAudioMode => {
+        CtlToUi::SetAudioTransmitMode => {
             let mode_byte = tlv.value.first().copied().unwrap_or(0);
-            let mode = AudioMode::try_from(mode_byte).unwrap_or(AudioMode::Net);
-            info!("ui: set audio mode = {:?}", mode);
+            let mode = AudioTransmitMode::try_from(mode_byte).unwrap_or(AudioTransmitMode::Net);
+            info!("ui: set audio transmit mode = {:?}", mode);
             audio_mode.store(mode as u8, Ordering::Relaxed);
             to_mgmt.must_write_tlv(UiToCtl::Ack, &[]).await;
         }
@@ -655,9 +655,9 @@ async fn handle_mgmt<M, N, I, D, B, const PLAYBACK_N: usize>(
         }
         CtlToUi::AudioFrame => {
             // Audio frame from CTL - only process when audio-mode=ctl
-            let mode =
-                AudioMode::try_from(audio_mode.load(Ordering::Relaxed)).unwrap_or(AudioMode::Net);
-            if mode != AudioMode::Ctl {
+            let mode = AudioTransmitMode::try_from(audio_mode.load(Ordering::Relaxed))
+                .unwrap_or(AudioTransmitMode::Net);
+            if mode != AudioTransmitMode::Ctl {
                 // Drop audio from CTL when not in ctl mode
                 return;
             }
@@ -847,7 +847,7 @@ mod tests {
         let loopback_mode = AtomicU8::new(UiLoopbackMode::Off as u8);
         let logs_enabled = AtomicBool::new(true);
         let volume = AtomicU8::new(255);
-        let audio_mode = AtomicU8::new(AudioMode::Net as u8);
+        let audio_mode = AtomicU8::new(AudioTransmitMode::Net as u8);
         let audio_received_path = AtomicU8::new(UiAudioReceivedPath::Headphones as u8);
         let playback_channel: Channel<CriticalSectionRawMutex, Frame, 4> = Channel::new();
         let mic_preamp = AtomicU8::new(255);
@@ -894,7 +894,7 @@ mod tests {
         let loopback_mode = AtomicU8::new(UiLoopbackMode::Off as u8);
         let logs_enabled = AtomicBool::new(true);
         let volume = AtomicU8::new(255);
-        let audio_mode = AtomicU8::new(AudioMode::Net as u8);
+        let audio_mode = AtomicU8::new(AudioTransmitMode::Net as u8);
         let audio_received_path = AtomicU8::new(UiAudioReceivedPath::Headphones as u8);
         let playback_channel: Channel<CriticalSectionRawMutex, Frame, 4> = Channel::new();
         let mic_preamp = AtomicU8::new(255);
@@ -947,7 +947,7 @@ mod tests {
         let loopback_mode = AtomicU8::new(UiLoopbackMode::Off as u8);
         let logs_enabled = AtomicBool::new(true);
         let volume = AtomicU8::new(255);
-        let audio_mode = AtomicU8::new(AudioMode::Net as u8);
+        let audio_mode = AtomicU8::new(AudioTransmitMode::Net as u8);
         let audio_received_path = AtomicU8::new(UiAudioReceivedPath::Headphones as u8);
         let playback_channel: Channel<CriticalSectionRawMutex, Frame, 4> = Channel::new();
         let mic_preamp = AtomicU8::new(255);
@@ -997,7 +997,7 @@ mod tests {
         let loopback_mode = AtomicU8::new(UiLoopbackMode::Off as u8);
         let logs_enabled = AtomicBool::new(true);
         let volume = AtomicU8::new(255);
-        let audio_mode = AtomicU8::new(AudioMode::Net as u8);
+        let audio_mode = AtomicU8::new(AudioTransmitMode::Net as u8);
         let audio_received_path = AtomicU8::new(UiAudioReceivedPath::Headphones as u8);
         let playback_channel: Channel<CriticalSectionRawMutex, Frame, 4> = Channel::new();
         let mic_preamp = AtomicU8::new(255);
@@ -1045,7 +1045,7 @@ mod tests {
         let loopback_mode = AtomicU8::new(UiLoopbackMode::Off as u8);
         let logs_enabled = AtomicBool::new(true);
         let volume = AtomicU8::new(255);
-        let audio_mode = AtomicU8::new(AudioMode::Net as u8);
+        let audio_mode = AtomicU8::new(AudioTransmitMode::Net as u8);
         let audio_received_path = AtomicU8::new(UiAudioReceivedPath::Headphones as u8);
         let playback_channel: Channel<CriticalSectionRawMutex, Frame, 4> = Channel::new();
         let mic_preamp = AtomicU8::new(255);
@@ -1093,7 +1093,7 @@ mod tests {
         let loopback_mode = AtomicU8::new(UiLoopbackMode::Off as u8);
         let logs_enabled = AtomicBool::new(true);
         let volume = AtomicU8::new(255);
-        let audio_mode = AtomicU8::new(AudioMode::Net as u8);
+        let audio_mode = AtomicU8::new(AudioTransmitMode::Net as u8);
         let audio_received_path = AtomicU8::new(UiAudioReceivedPath::Headphones as u8);
         let playback_channel: Channel<CriticalSectionRawMutex, Frame, 4> = Channel::new();
         let mic_preamp = AtomicU8::new(255);
@@ -1138,7 +1138,7 @@ mod tests {
         let loopback_mode = AtomicU8::new(UiLoopbackMode::Off as u8);
         let logs_enabled = AtomicBool::new(true);
         let volume = AtomicU8::new(255);
-        let audio_mode = AtomicU8::new(AudioMode::Net as u8);
+        let audio_mode = AtomicU8::new(AudioTransmitMode::Net as u8);
         let audio_received_path = AtomicU8::new(UiAudioReceivedPath::Ctl as u8);
         let playback_channel: Channel<CriticalSectionRawMutex, Frame, 4> = Channel::new();
         let mic_preamp = AtomicU8::new(255);
@@ -1185,7 +1185,7 @@ mod tests {
         let loopback_mode = AtomicU8::new(UiLoopbackMode::Off as u8);
         let logs_enabled = AtomicBool::new(true);
         let volume = AtomicU8::new(255);
-        let audio_mode = AtomicU8::new(AudioMode::Net as u8);
+        let audio_mode = AtomicU8::new(AudioTransmitMode::Net as u8);
         let audio_received_path = AtomicU8::new(UiAudioReceivedPath::Headphones as u8);
         let playback_channel: Channel<CriticalSectionRawMutex, Frame, 4> = Channel::new();
         let mic_preamp = AtomicU8::new(255);
@@ -2206,7 +2206,7 @@ mod audio_streaming_tests {
 
                 // Set audio mode to CTL
                 mgmt_to_ui
-                    .write_tlv(CtlToUi::SetAudioMode, &[AudioMode::Ctl as u8])
+                    .write_tlv(CtlToUi::SetAudioTransmitMode, &[AudioTransmitMode::Ctl as u8])
                     .await
                     .unwrap();
                 tokio::time::sleep(Duration::from_millis(50)).await;
@@ -2306,7 +2306,7 @@ mod audio_streaming_tests {
 
                 // Explicitly set audio mode to NET (should be default, but be explicit)
                 mgmt_to_ui
-                    .write_tlv(CtlToUi::SetAudioMode, &[AudioMode::Net as u8])
+                    .write_tlv(CtlToUi::SetAudioTransmitMode, &[AudioTransmitMode::Net as u8])
                     .await
                     .unwrap();
                 tokio::time::sleep(Duration::from_millis(50)).await;
@@ -2401,7 +2401,7 @@ mod audio_streaming_tests {
 
                 // Set audio mode to CTL
                 mgmt_to_ui
-                    .write_tlv(CtlToUi::SetAudioMode, &[AudioMode::Ctl as u8])
+                    .write_tlv(CtlToUi::SetAudioTransmitMode, &[AudioTransmitMode::Ctl as u8])
                     .await
                     .unwrap();
                 tokio::time::sleep(Duration::from_millis(50)).await;
@@ -2542,7 +2542,7 @@ mod audio_streaming_tests {
 
                 // Set audio mode to CTL
                 mgmt_to_ui
-                    .write_tlv(CtlToUi::SetAudioMode, &[AudioMode::Ctl as u8])
+                    .write_tlv(CtlToUi::SetAudioTransmitMode, &[AudioTransmitMode::Ctl as u8])
                     .await
                     .unwrap();
                 tokio::time::sleep(Duration::from_millis(50)).await;

--- a/link/src/ui/mod.rs
+++ b/link/src/ui/mod.rs
@@ -18,8 +18,8 @@ pub use log::{LogMessage, LogSender, MAX_LOG_SIZE};
 use crate::info;
 use crate::shared::{
     AdjDirection, AudioMode, Channel, ChannelId, Color, CriticalSectionRawMutex, CtlToUi, Led,
-    NetToUi, Sender, StackMonitor, Tlv, UiLoopbackMode, UiToCtl, UiToNet, WriteTlv, chunk,
-    read_tlv_loop,
+    NetToUi, Sender, StackMonitor, Tlv, UiAudioReceivedPath, UiLoopbackMode, UiToCtl, UiToNet,
+    WriteTlv, chunk, read_tlv_loop,
 };
 
 /// Board trait for UI chip.
@@ -119,6 +119,8 @@ where
 
     // Shared audio routing mode (Net or Ctl)
     let audio_mode = AtomicU8::new(AudioMode::Net as u8);
+    // Shared output path for audio received from NET.
+    let audio_received_path = AtomicU8::new(UiAudioReceivedPath::Headphones as u8);
     // Shared microphone preamp level (TODO: actually configure the audio system)
     let mic_preamp = AtomicU8::new(255);
 
@@ -152,6 +154,7 @@ where
                         &logs_enabled,
                         &volume,
                         &audio_mode,
+                        &audio_received_path,
                         &mic_preamp,
                         &mut sframe_state,
                         &playback_channel,
@@ -167,6 +170,27 @@ where
                             .unwrap_or(AudioMode::Net);
                         if mode == AudioMode::Ctl {
                             continue;
+                        }
+
+                        let received_path = UiAudioReceivedPath::try_from(
+                            audio_received_path.load(Ordering::Relaxed),
+                        )
+                        .unwrap_or(UiAudioReceivedPath::Headphones);
+
+                        match received_path {
+                            UiAudioReceivedPath::None => continue,
+                            UiAudioReceivedPath::Ctl => {
+                                to_mgmt
+                                    .must_write_tlv(UiToCtl::AudioFrame, &tlv.value)
+                                    .await;
+                                continue;
+                            }
+                            UiAudioReceivedPath::Both => {
+                                to_mgmt
+                                    .must_write_tlv(UiToCtl::AudioFrame, &tlv.value)
+                                    .await;
+                            }
+                            UiAudioReceivedPath::Headphones => {}
                         }
 
                         // New hactar format: channel_id (1 byte) + encrypted chunk
@@ -447,6 +471,7 @@ async fn handle_mgmt<M, N, I, D, B, const PLAYBACK_N: usize>(
     logs_enabled: &AtomicBool,
     volume: &AtomicU8,
     audio_mode: &AtomicU8,
+    audio_received_path: &AtomicU8,
     mic_preamp: &AtomicU8,
     sframe_state: &mut sframe::SFrameState,
     playback_channel: &Channel<CriticalSectionRawMutex, Frame, PLAYBACK_N>,
@@ -607,6 +632,25 @@ async fn handle_mgmt<M, N, I, D, B, const PLAYBACK_N: usize>(
             let mode = AudioMode::try_from(mode_byte).unwrap_or(AudioMode::Net);
             info!("ui: set audio mode = {:?}", mode);
             audio_mode.store(mode as u8, Ordering::Relaxed);
+            to_mgmt.must_write_tlv(UiToCtl::Ack, &[]).await;
+        }
+        CtlToUi::GetAudioReceivedPath => {
+            info!("ui: get audio received path");
+            let path = audio_received_path.load(Ordering::Relaxed);
+            to_mgmt
+                .must_write_tlv(UiToCtl::AudioReceivedPath, &[path])
+                .await;
+        }
+        CtlToUi::SetAudioReceivedPath => {
+            let path_byte = tlv
+                .value
+                .first()
+                .copied()
+                .unwrap_or(UiAudioReceivedPath::Headphones as u8);
+            let path =
+                UiAudioReceivedPath::try_from(path_byte).unwrap_or(UiAudioReceivedPath::Headphones);
+            info!("ui: set audio received path = {:?}", path);
+            audio_received_path.store(path as u8, Ordering::Relaxed);
             to_mgmt.must_write_tlv(UiToCtl::Ack, &[]).await;
         }
         CtlToUi::AudioFrame => {
@@ -804,6 +848,7 @@ mod tests {
         let logs_enabled = AtomicBool::new(true);
         let volume = AtomicU8::new(255);
         let audio_mode = AtomicU8::new(AudioMode::Net as u8);
+        let audio_received_path = AtomicU8::new(UiAudioReceivedPath::Headphones as u8);
         let playback_channel: Channel<CriticalSectionRawMutex, Frame, 4> = Channel::new();
         let mic_preamp = AtomicU8::new(255);
         let mut sframe_state = sframe::SFrameState::new(&[0u8; 16], 0);
@@ -817,6 +862,7 @@ mod tests {
             &logs_enabled,
             &volume,
             &audio_mode,
+            &audio_received_path,
             &mic_preamp,
             &mut sframe_state,
             &playback_channel,
@@ -849,6 +895,7 @@ mod tests {
         let logs_enabled = AtomicBool::new(true);
         let volume = AtomicU8::new(255);
         let audio_mode = AtomicU8::new(AudioMode::Net as u8);
+        let audio_received_path = AtomicU8::new(UiAudioReceivedPath::Headphones as u8);
         let playback_channel: Channel<CriticalSectionRawMutex, Frame, 4> = Channel::new();
         let mic_preamp = AtomicU8::new(255);
         let mut sframe_state = sframe::SFrameState::new(&[0u8; 16], 0);
@@ -862,6 +909,7 @@ mod tests {
             &logs_enabled,
             &volume,
             &audio_mode,
+            &audio_received_path,
             &mic_preamp,
             &mut sframe_state,
             &playback_channel,
@@ -900,6 +948,7 @@ mod tests {
         let logs_enabled = AtomicBool::new(true);
         let volume = AtomicU8::new(255);
         let audio_mode = AtomicU8::new(AudioMode::Net as u8);
+        let audio_received_path = AtomicU8::new(UiAudioReceivedPath::Headphones as u8);
         let playback_channel: Channel<CriticalSectionRawMutex, Frame, 4> = Channel::new();
         let mic_preamp = AtomicU8::new(255);
         let mut sframe_state = sframe::SFrameState::new(&[0u8; 16], 0);
@@ -913,6 +962,7 @@ mod tests {
             &logs_enabled,
             &volume,
             &audio_mode,
+            &audio_received_path,
             &mic_preamp,
             &mut sframe_state,
             &playback_channel,
@@ -948,6 +998,7 @@ mod tests {
         let logs_enabled = AtomicBool::new(true);
         let volume = AtomicU8::new(255);
         let audio_mode = AtomicU8::new(AudioMode::Net as u8);
+        let audio_received_path = AtomicU8::new(UiAudioReceivedPath::Headphones as u8);
         let playback_channel: Channel<CriticalSectionRawMutex, Frame, 4> = Channel::new();
         let mic_preamp = AtomicU8::new(255);
         let mut sframe_state = sframe::SFrameState::new(&[0u8; 16], 0);
@@ -961,6 +1012,7 @@ mod tests {
             &logs_enabled,
             &volume,
             &audio_mode,
+            &audio_received_path,
             &mic_preamp,
             &mut sframe_state,
             &playback_channel,
@@ -994,6 +1046,7 @@ mod tests {
         let logs_enabled = AtomicBool::new(true);
         let volume = AtomicU8::new(255);
         let audio_mode = AtomicU8::new(AudioMode::Net as u8);
+        let audio_received_path = AtomicU8::new(UiAudioReceivedPath::Headphones as u8);
         let playback_channel: Channel<CriticalSectionRawMutex, Frame, 4> = Channel::new();
         let mic_preamp = AtomicU8::new(255);
         let mut sframe_state = sframe::SFrameState::new(&[0u8; 16], 0);
@@ -1007,6 +1060,7 @@ mod tests {
             &logs_enabled,
             &volume,
             &audio_mode,
+            &audio_received_path,
             &mic_preamp,
             &mut sframe_state,
             &playback_channel,
@@ -1040,6 +1094,7 @@ mod tests {
         let logs_enabled = AtomicBool::new(true);
         let volume = AtomicU8::new(255);
         let audio_mode = AtomicU8::new(AudioMode::Net as u8);
+        let audio_received_path = AtomicU8::new(UiAudioReceivedPath::Headphones as u8);
         let playback_channel: Channel<CriticalSectionRawMutex, Frame, 4> = Channel::new();
         let mic_preamp = AtomicU8::new(255);
         let mut sframe_state = sframe::SFrameState::new(&[0u8; 16], 0);
@@ -1053,6 +1108,7 @@ mod tests {
             &logs_enabled,
             &volume,
             &audio_mode,
+            &audio_received_path,
             &mic_preamp,
             &mut sframe_state,
             &playback_channel,
@@ -1065,6 +1121,99 @@ mod tests {
         assert_eq!(to_mgmt.written[0].0, UiToCtl::Error);
         let mut eeprom = Eeprom::new(&mut i2c, &mut delay);
         assert_eq!(eeprom.get_sframe_key().unwrap(), [0xff; 16]);
+    }
+
+    #[tokio::test]
+    async fn tlv_get_audio_received_path() {
+        let mut to_mgmt = MockTlvWriter::new();
+        let mut to_net = DummyNetWriter;
+        let mut i2c = mock_i2c_with_eeprom();
+        let mut delay = MockDelay;
+
+        let tlv = Tlv {
+            tlv_type: CtlToUi::GetAudioReceivedPath,
+            value: Value::new(),
+        };
+
+        let loopback_mode = AtomicU8::new(UiLoopbackMode::Off as u8);
+        let logs_enabled = AtomicBool::new(true);
+        let volume = AtomicU8::new(255);
+        let audio_mode = AtomicU8::new(AudioMode::Net as u8);
+        let audio_received_path = AtomicU8::new(UiAudioReceivedPath::Ctl as u8);
+        let playback_channel: Channel<CriticalSectionRawMutex, Frame, 4> = Channel::new();
+        let mic_preamp = AtomicU8::new(255);
+        let mut sframe_state = sframe::SFrameState::new(&[0u8; 16], 0);
+        handle_mgmt(
+            tlv,
+            &mut to_mgmt,
+            &mut to_net,
+            &mut i2c,
+            &mut delay,
+            &loopback_mode,
+            &logs_enabled,
+            &volume,
+            &audio_mode,
+            &audio_received_path,
+            &mic_preamp,
+            &mut sframe_state,
+            &playback_channel,
+            &crate::shared::NoOpBoard,
+        )
+        .await;
+
+        assert_eq!(to_mgmt.written.len(), 1);
+        assert_eq!(to_mgmt.written[0].0, UiToCtl::AudioReceivedPath);
+        assert_eq!(to_mgmt.written[0].1, &[UiAudioReceivedPath::Ctl as u8]);
+    }
+
+    #[tokio::test]
+    async fn tlv_set_audio_received_path() {
+        let mut to_mgmt = MockTlvWriter::new();
+        let mut to_net = DummyNetWriter;
+        let mut i2c = mock_i2c_with_eeprom();
+        let mut delay = MockDelay;
+
+        let mut value: Value = Value::new();
+        value
+            .extend_from_slice(&[UiAudioReceivedPath::None as u8])
+            .unwrap();
+        let tlv = Tlv {
+            tlv_type: CtlToUi::SetAudioReceivedPath,
+            value,
+        };
+
+        let loopback_mode = AtomicU8::new(UiLoopbackMode::Off as u8);
+        let logs_enabled = AtomicBool::new(true);
+        let volume = AtomicU8::new(255);
+        let audio_mode = AtomicU8::new(AudioMode::Net as u8);
+        let audio_received_path = AtomicU8::new(UiAudioReceivedPath::Headphones as u8);
+        let playback_channel: Channel<CriticalSectionRawMutex, Frame, 4> = Channel::new();
+        let mic_preamp = AtomicU8::new(255);
+        let mut sframe_state = sframe::SFrameState::new(&[0u8; 16], 0);
+        handle_mgmt(
+            tlv,
+            &mut to_mgmt,
+            &mut to_net,
+            &mut i2c,
+            &mut delay,
+            &loopback_mode,
+            &logs_enabled,
+            &volume,
+            &audio_mode,
+            &audio_received_path,
+            &mic_preamp,
+            &mut sframe_state,
+            &playback_channel,
+            &crate::shared::NoOpBoard,
+        )
+        .await;
+
+        assert_eq!(to_mgmt.written.len(), 1);
+        assert_eq!(to_mgmt.written[0].0, UiToCtl::Ack);
+        assert_eq!(
+            audio_received_path.load(Ordering::Relaxed),
+            UiAudioReceivedPath::None as u8
+        );
     }
 }
 
@@ -1724,6 +1873,247 @@ mod audio_streaming_tests {
                 i, expected_values[i], frame.0[0]
             );
         }
+    }
+
+    #[tokio::test]
+    async fn net_audio_frame_forwards_to_ctl_when_received_path_ctl() {
+        use crate::shared::mocks::CapturingAudioStream;
+        use crate::shared::{MIN_START_LEVEL, WriteTlv};
+        use audio_codec_algorithms::decode_alaw;
+
+        let (ui_to_mgmt, mgmt_from_ui) = channel();
+        let (mut mgmt_to_ui, ui_from_mgmt) = channel();
+        let (ui_to_net, _net_from_ui) = channel();
+        let (mut net_to_ui, ui_from_net) = channel();
+
+        let (audio_stream, written_frames) = CapturingAudioStream::new();
+        let mut sframe_state = sframe::SFrameState::new(&[0xff; 16], 0);
+        let expected_forwarded = std::sync::Arc::new(std::sync::Mutex::new(None::<Vec<u8>>));
+        let expected_forwarded_task = expected_forwarded.clone();
+        let mgmt_collector = MgmtTlvCollector::new();
+        let expected_playback_sample = decode_alaw(0x5a) as u16;
+
+        tokio::select! {
+            _ = run(
+                ui_to_mgmt,
+                ui_from_mgmt,
+                ui_to_net,
+                ui_from_net,
+                mock_led_pins(),
+                MockButton,
+                MockButton,
+                MockButton,
+                mock_i2c_with_eeprom(),
+                MockDelay,
+                audio_stream,
+                NoOpBoard,
+            ) => unreachable!(),
+            _ = mgmt_collector.collect_from(mgmt_from_ui) => unreachable!(),
+            _ = async {
+                tokio::time::sleep(Duration::from_millis(300)).await;
+
+                mgmt_to_ui
+                    .write_tlv(CtlToUi::SetAudioReceivedPath, &[UiAudioReceivedPath::Ctl as u8])
+                    .await
+                    .unwrap();
+                tokio::time::sleep(Duration::from_millis(50)).await;
+
+                for _ in 0..MIN_START_LEVEL {
+                    let padding_frame = crate::ui::Frame::default();
+                    let encrypted = encrypt_frame_for_test(&padding_frame, &mut sframe_state);
+                    net_to_ui
+                        .write_tlv(crate::shared::NetToUi::AudioFrame, &encrypted)
+                        .await
+                        .unwrap();
+                }
+
+                let mut test_frame = crate::ui::Frame::default();
+                test_frame.0[0] = 0x5a;
+                let encrypted = encrypt_frame_for_test(&test_frame, &mut sframe_state);
+                *expected_forwarded_task.lock().unwrap() = Some(encrypted.to_vec());
+                net_to_ui
+                    .write_tlv(crate::shared::NetToUi::AudioFrame, &encrypted)
+                    .await
+                    .unwrap();
+
+                tokio::time::sleep(Duration::from_millis(200)).await;
+            } => {}
+        }
+
+        let forwarded = mgmt_collector.audio_frames.lock().unwrap();
+        assert!(
+            !forwarded.is_empty(),
+            "NET audio should be forwarded to CTL when received path=ctl"
+        );
+        assert_eq!(
+            forwarded.last().unwrap(),
+            expected_forwarded.lock().unwrap().as_ref().unwrap()
+        );
+        let found_locally = written_frames
+            .lock()
+            .unwrap()
+            .iter()
+            .any(|f| f.0[0] == expected_playback_sample);
+        assert!(
+            !found_locally,
+            "Forwarded NET audio should not also play out locally"
+        );
+    }
+
+    #[tokio::test]
+    async fn net_audio_frame_drops_when_received_path_none() {
+        use crate::shared::mocks::CapturingAudioStream;
+        use crate::shared::{MIN_START_LEVEL, WriteTlv};
+        use audio_codec_algorithms::{decode_alaw, encode_alaw};
+
+        let (ui_to_mgmt, mgmt_from_ui) = channel();
+        let (mut mgmt_to_ui, ui_from_mgmt) = channel();
+        let (ui_to_net, _net_from_ui) = channel();
+        let (mut net_to_ui, ui_from_net) = channel();
+
+        let (audio_stream, written_frames) = CapturingAudioStream::new();
+        let mut sframe_state = sframe::SFrameState::new(&[0xff; 16], 0);
+        let mgmt_collector = MgmtTlvCollector::new();
+        let test_alaw = encode_alaw(4321);
+        let expected_decoded = decode_alaw(test_alaw) as u16;
+
+        tokio::select! {
+            _ = run(
+                ui_to_mgmt,
+                ui_from_mgmt,
+                ui_to_net,
+                ui_from_net,
+                mock_led_pins(),
+                MockButton,
+                MockButton,
+                MockButton,
+                mock_i2c_with_eeprom(),
+                MockDelay,
+                audio_stream,
+                NoOpBoard,
+            ) => unreachable!(),
+            _ = mgmt_collector.collect_from(mgmt_from_ui) => unreachable!(),
+            _ = async {
+                tokio::time::sleep(Duration::from_millis(300)).await;
+
+                mgmt_to_ui
+                    .write_tlv(CtlToUi::SetAudioReceivedPath, &[UiAudioReceivedPath::None as u8])
+                    .await
+                    .unwrap();
+                tokio::time::sleep(Duration::from_millis(50)).await;
+
+                for _ in 0..MIN_START_LEVEL + 1 {
+                    let mut test_frame = crate::ui::Frame::default();
+                    test_frame.0[0] = test_alaw;
+                    let encrypted = encrypt_frame_for_test(&test_frame, &mut sframe_state);
+                    net_to_ui
+                        .write_tlv(crate::shared::NetToUi::AudioFrame, &encrypted)
+                        .await
+                        .unwrap();
+                }
+
+                tokio::time::sleep(Duration::from_millis(200)).await;
+            } => {}
+        }
+
+        let found_locally = written_frames
+            .lock()
+            .unwrap()
+            .iter()
+            .any(|f| f.0[0] == expected_decoded);
+        assert!(
+            !found_locally,
+            "Dropped NET audio should not play out locally"
+        );
+        assert!(
+            mgmt_collector.audio_frames.lock().unwrap().is_empty(),
+            "Dropped NET audio should not be forwarded to CTL"
+        );
+    }
+
+    #[tokio::test]
+    async fn net_audio_frame_forwards_and_plays_when_received_path_both() {
+        use crate::shared::mocks::CapturingAudioStream;
+        use crate::shared::{MIN_START_LEVEL, WriteTlv};
+        use audio_codec_algorithms::decode_alaw;
+
+        let (ui_to_mgmt, mgmt_from_ui) = channel();
+        let (mut mgmt_to_ui, ui_from_mgmt) = channel();
+        let (ui_to_net, _net_from_ui) = channel();
+        let (mut net_to_ui, ui_from_net) = channel();
+
+        let (audio_stream, written_frames) = CapturingAudioStream::new();
+        let mut sframe_state = sframe::SFrameState::new(&[0xff; 16], 0);
+        let expected_forwarded = std::sync::Arc::new(std::sync::Mutex::new(None::<Vec<u8>>));
+        let expected_forwarded_task = expected_forwarded.clone();
+        let mgmt_collector = MgmtTlvCollector::new();
+        let expected_playback_sample = decode_alaw(0x5a) as u16;
+
+        tokio::select! {
+            _ = run(
+                ui_to_mgmt,
+                ui_from_mgmt,
+                ui_to_net,
+                ui_from_net,
+                mock_led_pins(),
+                MockButton,
+                MockButton,
+                MockButton,
+                mock_i2c_with_eeprom(),
+                MockDelay,
+                audio_stream,
+                NoOpBoard,
+            ) => unreachable!(),
+            _ = mgmt_collector.collect_from(mgmt_from_ui) => unreachable!(),
+            _ = async {
+                tokio::time::sleep(Duration::from_millis(300)).await;
+
+                mgmt_to_ui
+                    .write_tlv(CtlToUi::SetAudioReceivedPath, &[UiAudioReceivedPath::Both as u8])
+                    .await
+                    .unwrap();
+                tokio::time::sleep(Duration::from_millis(50)).await;
+
+                for _ in 0..MIN_START_LEVEL {
+                    let padding_frame = crate::ui::Frame::default();
+                    let encrypted = encrypt_frame_for_test(&padding_frame, &mut sframe_state);
+                    net_to_ui
+                        .write_tlv(crate::shared::NetToUi::AudioFrame, &encrypted)
+                        .await
+                        .unwrap();
+                }
+
+                let mut test_frame = crate::ui::Frame::default();
+                test_frame.0[0] = 0x5a;
+                let encrypted = encrypt_frame_for_test(&test_frame, &mut sframe_state);
+                *expected_forwarded_task.lock().unwrap() = Some(encrypted.to_vec());
+                net_to_ui
+                    .write_tlv(crate::shared::NetToUi::AudioFrame, &encrypted)
+                    .await
+                    .unwrap();
+
+                tokio::time::sleep(Duration::from_millis(200)).await;
+            } => {}
+        }
+
+        let forwarded = mgmt_collector.audio_frames.lock().unwrap();
+        assert!(
+            !forwarded.is_empty(),
+            "NET audio should be forwarded to CTL when received path=both"
+        );
+        assert_eq!(
+            forwarded.last().unwrap(),
+            expected_forwarded.lock().unwrap().as_ref().unwrap()
+        );
+        let found_locally = written_frames
+            .lock()
+            .unwrap()
+            .iter()
+            .any(|f| f.0[0] == expected_playback_sample);
+        assert!(
+            found_locally,
+            "NET audio should also play locally when received path=both"
+        );
     }
 
     /// Collector for TLVs on the MGMT interface (CTL path).

--- a/link/src/ui/mod.rs
+++ b/link/src/ui/mod.rs
@@ -17,9 +17,9 @@ pub use log::{LogMessage, LogSender, MAX_LOG_SIZE};
 
 use crate::info;
 use crate::shared::{
-    AdjDirection, AudioTransmitMode, Channel, ChannelId, Color, CriticalSectionRawMutex,
-    CtlToUi, Led, NetToUi, Sender, StackMonitor, Tlv, UiAudioReceivedPath, UiLoopbackMode,
-    UiToCtl, UiToNet, WriteTlv, chunk, read_tlv_loop,
+    AdjDirection, AudioTransmitMode, Channel, ChannelId, Color, CriticalSectionRawMutex, CtlToUi,
+    Led, NetToUi, Sender, StackMonitor, Tlv, UiAudioReceivedPath, UiLoopbackMode, UiToCtl, UiToNet,
+    WriteTlv, chunk, read_tlv_loop,
 };
 
 /// Board trait for UI chip.
@@ -327,8 +327,9 @@ where
                     }
 
                     // Route based on audio mode
-                    let audio_routing = AudioTransmitMode::try_from(audio_mode.load(Ordering::Relaxed))
-                        .unwrap_or(AudioTransmitMode::Net);
+                    let audio_routing =
+                        AudioTransmitMode::try_from(audio_mode.load(Ordering::Relaxed))
+                            .unwrap_or(AudioTransmitMode::Net);
                     let channel_id_byte = [channel_id as u8];
 
                     if audio_routing == AudioTransmitMode::Ctl {
@@ -625,7 +626,9 @@ async fn handle_mgmt<M, N, I, D, B, const PLAYBACK_N: usize>(
         CtlToUi::GetAudioTransmitMode => {
             info!("ui: get audio transmit mode");
             let mode = audio_mode.load(Ordering::Relaxed);
-            to_mgmt.must_write_tlv(UiToCtl::AudioTransmitMode, &[mode]).await;
+            to_mgmt
+                .must_write_tlv(UiToCtl::AudioTransmitMode, &[mode])
+                .await;
         }
         CtlToUi::SetAudioTransmitMode => {
             let mode_byte = tlv.value.first().copied().unwrap_or(0);


### PR DESCRIPTION
## Summary

This PR adds new audio test and routing controls across `ctl`, `link`, `ui`, and `net` to make MoQ and end-to-end audio debugging easier.

## What changed

- Added UI loopback controls for `off`, `raw`, `alaw`, and `sframe`.
- Added NET loopback controls for `off`, `raw`, and `moq`.
- Added `blaster-send` commands for both UI and NET to push generated test payloads over the UART/TLV path.
- Added NET blaster state get/set support so payload blasting can be enabled and sized remotely.
- Split UI audio routing into separate transmit and receive controls:
  - transmit mode: `net`, `ctl`, `both`
  - received path: `none`, `headphones`, `ctl`, `both`
- Updated live capture and WAV capture flows to use configurable transmit and receive routing.
- Added support for unprotected UI audio frames in CTL capture logic alongside the existing SFrame path.
- Updated monitor reset behavior to use no-ack reset helpers so monitoring is more reliable when chips are mid-reset or not responding normally.
- Extended the shared protocol and `CtlCore` with the TLVs and control methods required for loopback, blaster, and audio-routing support.
- Added unit and integration test coverage for the new loopback, routing, blaster, and unprotected-audio paths.

## Why

These changes make it easier to inject test traffic, validate MoQ loopback behavior, and inspect audio routing at each stage of the UI <-> NET <-> CTL pipeline.

## Testing

- Added integration tests for UI and NET loopback behavior
- Added integration tests for UI audio received path settings
- Added unit tests for UI and NET blaster handling
- Added unit tests for unprotected audio capture handling